### PR TITLE
implement multistage docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+target/
+bin/
+docker/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,28 @@
-FROM gcr.io/distroless/base-debian12 as build
+# Build rust
+FROM rust:bookworm as rust-build
+
+RUN apt-get update && \
+	apt-get install pkg-config musl-tools libssl-dev
+
+RUN rustup update
+ENV RUSTFLAGS='-C target-feature=+crt-static'
+
+COPY . /src
+WORKDIR /src
+
+RUN rustup target add x86_64-unknown-linux-musl
+RUN cargo build --target x86_64-unknown-linux-musl --release
 
 
+# Final container
 FROM scratch
 WORKDIR /
 
-COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=rust-build /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=rust-build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-COPY ./m3u-filter /
-COPY ./web /web
+COPY --from=rust-build /src/target/x86_64-unknown-linux-musl/release/m3u-filter /m3u-filter
+COPY ./config /config
 
-CMD ["./m3u-filter", "-s", "-p", "/config"]
+ENTRYPOINT ["/m3u-filter"]
+CMD ["-s", "-p", "/config"]


### PR DESCRIPTION
I have updated your Dockerfile to use a multistage build to build the binary in a separate container and then copy it to the scratch container. This makes it work all in one docker build without having to install/setup/configure rust on the host. 

You can easily add a github action to this to have it build and publish your container image if you'd like. 

I can add the frontend build as well, but I couldn't get it to build. When I run `npm install` I get this error:

![image](https://github.com/euzu/m3u-filter/assets/160749165/aabcfccd-7f76-406a-940b-67e3e9952557)
