### PR TITLE
Update Dockerfile to add ffmpeg build stage to generate freeze_frame.ts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-# Build rust
+# Build rust stage
 FROM rust:bookworm as rust-build
 
 RUN apt-get update && \
-	apt-get install pkg-config musl-tools libssl-dev
+  apt-get install pkg-config musl-tools libssl-dev
 
 RUN rustup update
 ENV RUSTFLAGS='--remap-path-prefix $HOME=~ -C target-feature=+crt-static'
@@ -13,6 +13,7 @@ WORKDIR /src
 RUN rustup target add x86_64-unknown-linux-musl
 RUN cargo build --target x86_64-unknown-linux-musl --release
 
+# Build node stage
 FROM node:lts as node-build
 
 ENV NODE_OPTIONS=--openssl-legacy-provider
@@ -25,39 +26,34 @@ RUN yarn install \
   --frozen-lockfile \
   --non-interactive \
   --production=false
-
 RUN yarn build
-
 RUN rm -rf node_modules
 
-# Final container
+# Build resource stage (using ffmpeg)
+FROM jrottenberg/ffmpeg:latest as resource-build
+WORKDIR /src
+COPY resources ./resources
+RUN ffmpeg -loop 1 -i ./resources/freeze_frame.jpg -t 10 -r 1 -an \
+  -c:v libx264 -preset veryfast -crf 23 -pix_fmt yuv420p \
+  ./resources/freeze_frame.ts
+
+# Final container (Scratch)
 FROM scratch as scratch-final
 WORKDIR /
-
 COPY --from=rust-build /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=rust-build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
 COPY --from=rust-build /src/target/x86_64-unknown-linux-musl/release/m3u-filter /m3u-filter
 COPY --from=node-build /app/build /web
-COPY ./freeze_frame.ts /freeze_frame.ts
-# config should be mounted as volume
-# COPY ./config /config
-
+COPY --from=resource-build /src/resources/freeze_frame.ts /freeze_frame.ts
 ENTRYPOINT ["/m3u-filter"]
 CMD ["-s", "-p", "/config"]
 
-# Final container
+# Final container (Alpine)
 FROM alpine:latest as alpine-final
-
 RUN apk add --no-cache bash curl ca-certificates tini
-
 WORKDIR /app
-
 COPY --from=rust-build /src/target/x86_64-unknown-linux-musl/release/m3u-filter m3u-filter
 COPY --from=node-build /app/build web
-COPY ./freeze_frame.ts /freeze_frame.ts
-# config should be mounted as volume
-# COPY ./config config
-
+COPY --from=resource-build /src/resources/freeze_frame.ts /freeze_frame.ts
 ENTRYPOINT ["/sbin/tini", "--", "/app/m3u-filter"]
 CMD ["-s", "-p", "/app/config"]


### PR DESCRIPTION
This pull request adds a new build stage that uses ffmpeg to generate the freeze_frame.ts resource during the build process, ensuring it's available in the final images without relying on repository assets.