### PR TITLE
the endpoint was serving an empty epg content when no credentials given,now FORBIDDEN is returned

### DIFF
--- a/src/api/endpoints/xmltv_api.rs
+++ b/src/api/endpoints/xmltv_api.rs
@@ -170,6 +170,17 @@ fn serve_epg_with_timeshift(epg_file: File, offset_minutes: i32) -> impl axum::r
         .into_response()
 }
 
+/// Handles XMLTV EPG API requests, serving the appropriate EPG file with optional time-shifting based on user configuration.
+///
+/// Returns a 403 Forbidden response if the user or target is invalid or if the user lacks permission. If no EPG file is configured for the target, returns an empty EPG response. Otherwise, serves the EPG file, applying a time shift if specified by the user.
+///
+/// # Examples
+///
+/// ```
+/// // Example usage within an Axum router:
+/// let router = xmltv_api_register();
+/// // A GET request to /xmltv.php with valid query parameters will invoke this handler.
+/// ```
 async fn xmltv_api(
     axum::extract::Query(api_req): axum::extract::Query<UserApiRequest>,
     axum::extract::State(app_state): axum::extract::State<Arc<AppState>>,
@@ -191,6 +202,16 @@ async fn xmltv_api(
     serve_epg(&epg_path, &user).await.into_response()
 }
 
+/// Registers the XMLTV EPG API routes for handling HTTP GET requests.
+///
+/// The returned router maps the `/xmltv.php`, `/update/epg.php`, and `/epg` endpoints to the `xmltv_api` handler, enabling XMLTV EPG data retrieval with optional time-shifting and compression.
+///
+/// # Examples
+///
+/// ```
+/// let router = xmltv_api_register();
+/// // The router can now be used with an Axum server.
+/// ```
 pub fn xmltv_api_register() -> axum::Router<Arc<AppState>> {
     axum::Router::new()
         .route("/xmltv.php", axum::routing::get(xmltv_api))


### PR DESCRIPTION
the endpoint was serving an empty epg content when no credentials given,now FORBIDDEN is returned
@coderabbitai fill review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and improved the XMLTV API endpoint for more efficient handling of user permissions and EPG file serving, enhancing overall reliability without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->