### PR TITLE
Feature/web UI enhancements

### DIFF
--- a/backend/src/api/endpoints/v1_api.rs
+++ b/backend/src/api/endpoints/v1_api.rs
@@ -15,7 +15,7 @@ use axum::response::IntoResponse;
 use log::error;
 use serde_json::json;
 use shared::error::TuliproxError;
-use shared::model::{ApiProxyConfigDto, ApiProxyServerInfoDto, ConfigDto, InputType, IpCheckDto, PlaylistRequest, PlaylistRequestType, StatusCheck, TargetUserDto, XtreamPlaylistItem};
+use shared::model::{ApiProxyConfigDto, ApiProxyServerInfoDto, ConfigDto, InputType, IpCheckDto, PlaylistRequest, PlaylistRequestType, StatusCheck, TargetUserDto, WebplayerUrlRequest};
 use shared::utils::{concat_path_leading_slash, sanitize_sensitive_info};
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
@@ -233,16 +233,15 @@ async fn playlist_content(
 }
 
 async fn playlist_webplayer(
-    axum::extract::Path(target_id): axum::extract::Path<u32>,
     axum::extract::State(app_state): axum::extract::State<Arc<AppState>>,
-    axum::extract::Json(playlist_item): axum::extract::Json<XtreamPlaylistItem>,
+    axum::extract::Json(playlist_item): axum::extract::Json<WebplayerUrlRequest>,
 ) -> impl axum::response::IntoResponse + Send {
-    let access_token = create_access_token(&app_state.app_config.access_token_secret, 5);
+    let access_token = create_access_token(&app_state.app_config.access_token_secret, 30);
     let config = app_state.app_config.config.load();
     let server_name = config.web_ui.as_ref().and_then(|web_ui| web_ui.player_server.as_ref()).map_or("default", |server_name| server_name.as_str());
     let server_info = app_state.app_config.get_server_info(server_name);
     let base_url = server_info.get_base_url();
-    format!("{base_url}/token/{access_token}/{target_id}/{}/{}", playlist_item.xtream_cluster.as_stream_type(), playlist_item.virtual_id).into_response()
+    format!("{base_url}/token/{access_token}/{}/{}/{}", playlist_item.target_id, playlist_item.cluster.as_stream_type(), playlist_item.virtual_id).into_response()
 }
 
 async fn config(
@@ -364,7 +363,7 @@ pub fn v1_api_register(web_auth_enabled: bool, app_state: Arc<AppState>, web_ui_
         .route("/config/main", axum::routing::post(save_config_main))
         .route("/config/user", axum::routing::post(save_config_api_proxy_user))
         .route("/config/apiproxy", axum::routing::post(save_config_api_proxy_config))
-        .route("/playlist/webplayer/{target_id}", axum::routing::post(playlist_webplayer))
+        .route("/playlist/webplayer", axum::routing::post(playlist_webplayer))
         .route("/playlist/update", axum::routing::post(playlist_update))
         .route("/playlist", axum::routing::post(playlist_content))
         .route("/file/download", axum::routing::post(download_api::queue_download_file))

--- a/backend/src/model/config/api_proxy.rs
+++ b/backend/src/model/config/api_proxy.rs
@@ -10,6 +10,9 @@ use arc_swap::ArcSwap;
 use shared::model::{ApiProxyConfigDto, ApiProxyServerInfoDto, ConfigPaths, TargetUserDto};
 use crate::{utils};
 
+const API_USER: &str = "api";
+const TEST_USER: &str = "test";
+
 #[derive(Debug, Clone)]
 pub struct ApiProxyServerInfo {
     pub name: String,
@@ -167,7 +170,7 @@ impl ApiProxyConfig {
                 return Some((credentials.clone(), target_name.to_string()));
             }
         }
-        if log::log_enabled!(log::Level::Debug) && !username.eq("api") {
+        if log::log_enabled!(log::Level::Debug) && !username.eq(API_USER) {
            debug!("Could not find any target for user {username}");
         }
         None
@@ -187,7 +190,7 @@ impl ApiProxyConfig {
             .flat_map(|target_user| &target_user.credentials)
             .find(|credential| credential.username == username)
             .cloned();
-        if result.is_none() && (username != "test" || username != "api") {
+        if result.is_none() && (username != TEST_USER || username != API_USER) {
             debug!("Could not find any user credentials for: {username}");
         }
         result

--- a/frontend/public/assets/i18n/en.json
+++ b/frontend/public/assets/i18n/en.json
@@ -242,8 +242,9 @@
     "NAME_PREFIX": "Name Prefix",
     "NAME_PREFIX_SEPARATOR":"Name Prefix Separator",
     "STRIP": "Strip",
-    "COPY_LINK_TULIPROX": "Copy Virtual Id",
-    "COPY_LINK_PROVIDER": "Copy Provider Url",
+    "COPY_LINK_TULIPROX_VIRTUAL_ID": "Copy Virtual Id",
+    "COPY_LINK_TULIPROX_WEBPLAYER_URL": "Copy Webplayer Url",
+    "COPY_LINK_PROVIDER_URL": "Copy Provider Url",
     "CONTENT_SECURITY_POLICY" : "Content Security Policy"
   },
   "TABLE": {
@@ -329,6 +330,9 @@
       "FAIL_FINISH": "Playlist update failed!",
       "URL_MANDATORY": "Url is mandatory!",
       "USERNAME_PASSWORD_MANDATORY": "Username and Password are mandatory!"
+    },
+    "PLAYLIST": {
+      "WEBPLAYER_URL_COPY_TO_CLIPBOARD": "The copied WebPlayer url is valid for 30 seconds."
     },
     "SOURCE_SELECTOR": {
       "MISSING_SELECTION": "No entry selected"

--- a/frontend/scss/app/components/config/_config_view.scss
+++ b/frontend/scss/app/components/config/_config_view.scss
@@ -1,3 +1,7 @@
+$config-grid-cell-width: 400px;
+$config-max-grid-cells: 3;
+$config-field-min-width: 200px;
+
 .tp__config-view {
   display: flex;
   flex-flow: column;
@@ -54,7 +58,7 @@
   display: flex;
   gap: var(--gap-default);
   box-sizing: border-box;
-  min-width: 200px;
+  min-width: $config-field-min-width;
 
   &__text {
     flex-flow: column;
@@ -80,6 +84,7 @@
 
   &__bool {
     flex-flow: row;
+    align-items: center;
   }
 
   label {
@@ -102,7 +107,8 @@
 
   &__header {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax($config-grid-cell-width, 1fr));
+    max-width: calc($config-max-grid-cells * $config-grid-cell-width + 2 * 1rem);
     gap: var(--gap-large);
     box-sizing: border-box;
     width: 100%;
@@ -110,7 +116,8 @@
 
   &__body {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax($config-grid-cell-width, 1fr));
+    max-width: calc($config-max-grid-cells * $config-grid-cell-width + 2 * 1rem);
     gap: var(--gap-large);
     box-sizing: border-box;
     width: 100%;
@@ -120,7 +127,8 @@
 .tp__schedules-config-view {
   &__schedule {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax($config-grid-cell-width, 1fr));
+    max-width: calc($config-max-grid-cells * $config-grid-cell-width + 2 * 1rem);
     gap: var(--gap-default);
     box-sizing: border-box;
     padding: var(--padding-default);

--- a/frontend/src/app/components/config/api_config_view.rs
+++ b/frontend/src/app/components/config/api_config_view.rs
@@ -1,8 +1,12 @@
-use crate::app::components::{NoContent};
 use crate::app::ConfigContext;
 use yew::prelude::*;
 use yew_i18n::use_translation;
-use crate::{config_field};
+use crate::{config_field, config_field_empty};
+
+const LABEL_HOST: &str =  "LABEL.HOST";
+const LABEL_PORT: &str =  "LABEL.PORT";
+const LABEL_WEB_ROOT: &str =  "LABEL.WEB_ROOT";
+
 
 #[function_component]
 pub fn ApiConfigView() -> Html {
@@ -17,12 +21,20 @@ pub fn ApiConfigView() -> Html {
                         Some(config) => {
                             html!{
                             <>
-                            { config_field!(config.config.api, translate.t("LABEL.HOST"), host) }
-                            { config_field!(config.config.api, translate.t("LABEL.PORT"), port) }
-                            { config_field!(config.config.api, translate.t("LABEL.WEB_ROOT"), web_root) }
+                            { config_field!(config.config.api, translate.t(LABEL_HOST), host) }
+                            { config_field!(config.config.api, translate.t(LABEL_PORT), port) }
+                            { config_field!(config.config.api, translate.t(LABEL_WEB_ROOT), web_root) }
                             </>
                         }},
-                        None => html! { <NoContent /> }
+                        None => {
+                            html!{
+                            <>
+                            { config_field_empty!(translate.t(LABEL_HOST)) }
+                            { config_field_empty!(translate.t(LABEL_PORT)) }
+                            { config_field_empty!(translate.t(LABEL_WEB_ROOT)) }
+                            </>
+                         }
+                        }
                     }
                 }
             </div>

--- a/frontend/src/app/components/config/ipcheck_config_view.rs
+++ b/frontend/src/app/components/config/ipcheck_config_view.rs
@@ -3,6 +3,13 @@ use yew_i18n::use_translation;
 use crate::app::context::ConfigContext;
 use crate::{config_field_empty, config_field_optional};
 
+const LABEL_URL: &str =  "LABEL.URL";
+const LABEL_URL_IPV4: &str =  "LABEL.URL_IPV4";
+const LABEL_URL_IPV6: &str =  "LABEL.URL_IPV6";
+const LABEL_PATTERN_IPV4: &str =  "LABEL.PATTERN_IPV4";
+const LABEL_PATTERN_IPV6: &str =  "LABEL.PATTERN_IPV6";
+
+
 #[function_component]
 pub fn IpCheckConfigView() -> Html {
     let translate = use_translation();
@@ -11,11 +18,11 @@ pub fn IpCheckConfigView() -> Html {
     let render_empty = || {
             html! {
               <>
-                { config_field_empty!(translate.t("LABEL.URL")) }
-                { config_field_empty!(translate.t("LABEL.URL_IPV4")) }
-                { config_field_empty!(translate.t("LABEL.URL_IPV6")) }
-                { config_field_empty!(translate.t("LABEL.PATTERN_IPV4")) }
-                { config_field_empty!(translate.t("LABEL.PATTERN_IPV6")) }
+                { config_field_empty!(translate.t(LABEL_URL)) }
+                { config_field_empty!(translate.t(LABEL_URL_IPV4)) }
+                { config_field_empty!(translate.t(LABEL_URL_IPV6)) }
+                { config_field_empty!(translate.t(LABEL_PATTERN_IPV4)) }
+                { config_field_empty!(translate.t(LABEL_PATTERN_IPV6)) }
               </>
             }
     };
@@ -28,11 +35,11 @@ pub fn IpCheckConfigView() -> Html {
                     if let Some(ipcheck) = &config.config.ipcheck {
                         html! {
                           <>
-                            { config_field_optional!(ipcheck, translate.t("LABEL.URL"),  url) }
-                            { config_field_optional!(ipcheck, translate.t("LABEL.URL_IPV4"),  url_ipv4) }
-                            { config_field_optional!(ipcheck, translate.t("LABEL.URL_IPV6"),  url_ipv6) }
-                            { config_field_optional!(ipcheck, translate.t("LABEL.PATTERN_IPV4"),  pattern_ipv4) }
-                            { config_field_optional!(ipcheck, translate.t("LABEL.PATTERN_IPV6"),  pattern_ipv6) }
+                            { config_field_optional!(ipcheck, translate.t(LABEL_URL),  url) }
+                            { config_field_optional!(ipcheck, translate.t(LABEL_URL_IPV4),  url_ipv4) }
+                            { config_field_optional!(ipcheck, translate.t(LABEL_URL_IPV6),  url_ipv6) }
+                            { config_field_optional!(ipcheck, translate.t(LABEL_PATTERN_IPV4),  pattern_ipv4) }
+                            { config_field_optional!(ipcheck, translate.t(LABEL_PATTERN_IPV6),  pattern_ipv6) }
                           </>
                         }
                     } else {

--- a/frontend/src/app/components/config/main_config_view.rs
+++ b/frontend/src/app/components/config/main_config_view.rs
@@ -1,8 +1,20 @@
-use crate::app::components::{NoContent};
 use crate::app::ConfigContext;
 use yew::prelude::*;
 use yew_i18n::use_translation;
-use crate::{config_field, config_field_bool, config_field_optional};
+use crate::{config_field, config_field_bool, config_field_bool_empty, config_field_empty, config_field_optional};
+
+const LABEL_UPDATE_ON_BOOT: &str = "LABEL.UPDATE_ON_BOOT";
+const LABEL_CONFIG_HOT_RELOAD: &str = "LABEL.CONFIG_HOT_RELOAD";
+const LABEL_USER_ACCESS_CONTROL: &str = "LABEL.USER_ACCESS_CONTROL";
+const LABEL_THREADS: &str = "LABEL.THREADS";
+const LABEL_WORKING_DIR: &str = "LABEL.WORKING_DIR";
+const LABEL_MAPPING_PATH: &str = "LABEL.MAPPING_PATH";
+const LABEL_BACKUP_DIR: &str = "LABEL.BACKUP_DIR";
+const LABEL_USER_CONFIG_DIR: &str = "LABEL.USER_CONFIG_DIR";
+const LABEL_SLEEP_TIMER_MINS: &str = "LABEL.SLEEP_TIMER_MINS";
+const LABEL_CONNECT_TIMEOUT_SECS: &str = "LABEL.CONNECT_TIMEOUT_SECS";
+const LABEL_CUSTOM_STREAM_RESPONSE_PATH: &str = "LABEL.CUSTOM_STREAM_RESPONSE_PATH";
+
 
 #[function_component]
 pub fn MainConfigView() -> Html {
@@ -17,21 +29,37 @@ pub fn MainConfigView() -> Html {
                         Some(config) => {
                             html!{
                             <>
-                            { config_field_bool!(config.config, translate.t("LABEL.UPDATE_ON_BOOT"), update_on_boot) }
-                            { config_field_bool!(config.config, translate.t("LABEL.CONFIG_HOT_RELOAD"), config_hot_reload) }
-                            { config_field_bool!(config.config, translate.t("LABEL.USER_ACCESS_CONTROL"), user_access_control) }
-                            { config_field!(config.config, translate.t("LABEL.THREADS"), threads) }
-                            { config_field!(config.config, translate.t("LABEL.WORKING_DIR"), working_dir) }
-                            { config_field_optional!(config.config, translate.t("LABEL.MAPPING_PATH"), mapping_path) }
-                            { config_field_optional!(config.config, translate.t("LABEL.BACKUP_DIR"), backup_dir) }
-                            { config_field_optional!(config.config, translate.t("LABEL.USER_CONFIG_DIR"), user_config_dir) }
-                            { config_field_optional!(config.config, translate.t("LABEL.SLEEP_TIMER_MINS"), sleep_timer_mins) }
-                            { config_field!(config.config, translate.t("LABEL.CONNECT_TIMEOUT_SECS"), connect_timeout_secs) }
-                            { config_field_optional!(config.config, translate.t("LABEL.CUSTOM_STREAM_RESPONSE_PATH"), custom_stream_response_path) }
+                            { config_field_bool!(config.config, translate.t(LABEL_UPDATE_ON_BOOT), update_on_boot) }
+                            { config_field_bool!(config.config, translate.t(LABEL_CONFIG_HOT_RELOAD), config_hot_reload) }
+                            { config_field_bool!(config.config, translate.t(LABEL_USER_ACCESS_CONTROL), user_access_control) }
+                            { config_field!(config.config, translate.t(LABEL_THREADS), threads) }
+                            { config_field!(config.config, translate.t(LABEL_WORKING_DIR), working_dir) }
+                            { config_field_optional!(config.config, translate.t(LABEL_MAPPING_PATH), mapping_path) }
+                            { config_field_optional!(config.config, translate.t(LABEL_BACKUP_DIR), backup_dir) }
+                            { config_field_optional!(config.config, translate.t(LABEL_USER_CONFIG_DIR), user_config_dir) }
+                            { config_field_optional!(config.config, translate.t(LABEL_SLEEP_TIMER_MINS), sleep_timer_mins) }
+                            { config_field!(config.config, translate.t(LABEL_CONNECT_TIMEOUT_SECS), connect_timeout_secs) }
+                            { config_field_optional!(config.config, translate.t(LABEL_CUSTOM_STREAM_RESPONSE_PATH), custom_stream_response_path) }
                             </>
                         }},
-                        None => html! { <NoContent /> }
+                        None => {
+                            html!{
+                            <>
+                            { config_field_bool_empty!(translate.t(LABEL_UPDATE_ON_BOOT)) }
+                            { config_field_bool_empty!(translate.t(LABEL_CONFIG_HOT_RELOAD)) }
+                            { config_field_bool_empty!(translate.t(LABEL_USER_ACCESS_CONTROL)) }
+                            { config_field_empty!(translate.t(LABEL_THREADS)) }
+                            { config_field_empty!(translate.t(LABEL_WORKING_DIR)) }
+                            { config_field_empty!(translate.t(LABEL_MAPPING_PATH)) }
+                            { config_field_empty!(translate.t(LABEL_BACKUP_DIR)) }
+                            { config_field_empty!(translate.t(LABEL_USER_CONFIG_DIR)) }
+                            { config_field_empty!(translate.t(LABEL_SLEEP_TIMER_MINS)) }
+                            { config_field_empty!(translate.t(LABEL_CONNECT_TIMEOUT_SECS)) }
+                            { config_field_empty!(translate.t(LABEL_CUSTOM_STREAM_RESPONSE_PATH)) }
+                            </>
+                       }
                     }
+                  }
                 }
             </div>
         </div>

--- a/frontend/src/app/components/config/messaging_config_view.rs
+++ b/frontend/src/app/components/config/messaging_config_view.rs
@@ -5,6 +5,17 @@ use shared::model::{PushoverMessagingConfigDto, RestMessagingConfigDto, Telegram
 use yew::prelude::*;
 use yew_i18n::use_translation;
 
+const LABEL_NOTIFY_ON: &str = "LABEL.NOTIFY_ON";
+const LABEL_TELEGRAM: &str = "LABEL.TELEGRAM";
+const LABEL_PUSHOVER: &str = "LABEL.PUSHOVER";
+const LABEL_REST: &str = "LABEL.REST";
+const LABEL_BOT_TOKEN: &str = "LABEL.BOT_TOKEN";
+const LABEL_CHAT_IDS: &str = "LABEL.CHAT_IDS";
+const LABEL_URL: &str = "LABEL.URL";
+const LABEL_TOKEN: &str = "LABEL.TOKEN";
+const LABEL_USER: &str = "LABEL.USER";
+
+
 #[function_component]
 pub fn MessagingConfigView() -> Html {
     let translate = use_translation();
@@ -15,8 +26,8 @@ pub fn MessagingConfigView() -> Html {
             Some(entry) => html! {
             <Card class="tp__config-view__card">
                 <h1>{translate.t("LABEL.TELEGRAM")}</h1>
-                { config_field!(entry, translate.t("LABEL.BOT_TOKEN"), bot_token) }
-                { config_field_child!(translate.t("LABEL.CHAT_IDS"), {
+                { config_field!(entry, translate.t(LABEL_BOT_TOKEN), bot_token) }
+                { config_field_child!(translate.t(LABEL_CHAT_IDS), {
                     html! {
                         <div class="tp__config-view__tags">
                             {
@@ -33,9 +44,9 @@ pub fn MessagingConfigView() -> Html {
           },
             None => html! {
             <Card class="tp__config-view__card">
-               <h1>{translate.t("LABEL.TELEGRAM")}</h1>
-               { config_field_empty!(translate.t("LABEL.BOT_TOKEN")) }
-               { config_field_empty!(translate.t("LABEL.CHAT_IDS")) }
+               <h1>{translate.t(LABEL_TELEGRAM)}</h1>
+               { config_field_empty!(translate.t(LABEL_BOT_TOKEN)) }
+               { config_field_empty!(translate.t(LABEL_CHAT_IDS)) }
             </Card>
           },
         }
@@ -45,14 +56,14 @@ pub fn MessagingConfigView() -> Html {
         match rest {
             Some(entry) => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.REST")}</h1>
-                { config_field!(entry, translate.t("LABEL.URL"), url) }
+                <h1>{translate.t(LABEL_REST)}</h1>
+                { config_field!(entry, translate.t(LABEL_URL), url) }
             </Card>
           },
             None => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.REST")}</h1>
-                { config_field_empty!(translate.t("LABEL.URL")) }
+                <h1>{translate.t(LABEL_REST)}</h1>
+                { config_field_empty!(translate.t(LABEL_URL)) }
             </Card>
           },
         }
@@ -62,18 +73,18 @@ pub fn MessagingConfigView() -> Html {
         match pushover {
             Some(entry) => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.PUSHOVER")}</h1>
-                { config_field_optional!(entry, translate.t("LABEL.URL"), url) }
-                { config_field_hide!(entry, translate.t("LABEL.TOKEN"), token) }
-                { config_field!(entry, translate.t("LABEL.USER"), user) }
+                <h1>{translate.t(LABEL_PUSHOVER)}</h1>
+                { config_field_optional!(entry, translate.t(LABEL_URL), url) }
+                { config_field_hide!(entry, translate.t(LABEL_TOKEN), token) }
+                { config_field!(entry, translate.t(LABEL_USER), user) }
             </Card>
             },
             None => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.PUSHOVER")}</h1>
-                { config_field_empty!(translate.t("LABEL.URL")) }
-                { config_field_empty!(translate.t("LABEL.TOKEN")) }
-                { config_field_empty!(translate.t("LABEL.USER")) }
+                <h1>{translate.t(LABEL_PUSHOVER)}</h1>
+                { config_field_empty!(translate.t(LABEL_URL)) }
+                { config_field_empty!(translate.t(LABEL_TOKEN)) }
+                { config_field_empty!(translate.t(LABEL_USER)) }
             </Card>
           },
         }
@@ -83,7 +94,7 @@ pub fn MessagingConfigView() -> Html {
         html! {
           <>
             <div class="tp__messaging-config-view__header tp__config-view-page__header">
-             { config_field_empty!(translate.t("LABEL.NOTIFY_ON")) }
+             { config_field_empty!(translate.t(LABEL_NOTIFY_ON)) }
             </div>
             <div class="tp__messaging-config-view__body tp__config-view-page__body">
              {render_telegram(None)}
@@ -102,7 +113,7 @@ pub fn MessagingConfigView() -> Html {
                         html! {
                           <>
                         <div class="tp__messaging-config-view__header tp__config-view-page__header">
-                          { config_field_child!(translate.t("LABEL.NOTIFY_ON"), {
+                          { config_field_child!(translate.t(LABEL_NOTIFY_ON), {
                              html! { <div class="tp__messaging-config-view__notify-on">
                                 { for messaging.notify_on.iter().map(|t| html! { <Chip label={t.to_string()} /> }) }
                             </div> }

--- a/frontend/src/app/components/config/proxy_config_view.rs
+++ b/frontend/src/app/components/config/proxy_config_view.rs
@@ -3,6 +3,11 @@ use yew_i18n::use_translation;
 use crate::app::context::ConfigContext;
 use crate::{config_field, config_field_empty, config_field_optional, config_field_optional_hide};
 
+const LABEL_URL: &str = "LABEL.URL";
+const LABEL_USERNAME: &str = "LABEL.USERNAME";
+const LABEL_PASSWORD: &str = "LABEL.PASSWORD";
+
+
 #[function_component]
 pub fn ProxyConfigView() -> Html {
     let translate = use_translation();
@@ -11,9 +16,9 @@ pub fn ProxyConfigView() -> Html {
     let render_empty = || {
         html! {
           <div class="tp__proxy-config-config-view__body tp__config-view-page__body">
-            { config_field_empty!(translate.t("LABEL.URL")) }
-            { config_field_empty!(translate.t("LABEL.USERNAME")) }
-            { config_field_empty!(translate.t("LABEL.PASSWORD")) }
+            { config_field_empty!(translate.t(LABEL_URL)) }
+            { config_field_empty!(translate.t(LABEL_USERNAME)) }
+            { config_field_empty!(translate.t(LABEL_PASSWORD)) }
           </div>
         }
     };
@@ -26,9 +31,9 @@ pub fn ProxyConfigView() -> Html {
                         html! {
                          <>
                           <div class="tp__proxy-config-config-view__body tp__config-view-page__body">
-                            { config_field!(proxy, translate.t("LABEL.URL"), url) }
-                            { config_field_optional!(proxy, translate.t("LABEL.USERNAME"), username) }
-                            { config_field_optional_hide!(proxy, translate.t("LABEL.PASSWORD"), password) }
+                            { config_field!(proxy, translate.t(LABEL_URL), url) }
+                            { config_field_optional!(proxy, translate.t(LABEL_USERNAME), username) }
+                            { config_field_optional_hide!(proxy, translate.t(LABEL_PASSWORD), password) }
                           </div>
                          </>
                         }

--- a/frontend/src/app/components/config/reverse_proxy_config_view.rs
+++ b/frontend/src/app/components/config/reverse_proxy_config_view.rs
@@ -5,6 +5,27 @@ use crate::app::context::ConfigContext;
 use crate::{config_field, config_field_bool, config_field_bool_empty, config_field_empty, config_field_optional};
 use crate::app::components::Card;
 
+const LABEL_CACHE: &str =  "LABEL.CACHE";
+const LABEL_ENABLED: &str =  "LABEL.ENABLED";
+const LABEL_SIZE: &str =  "LABEL.SIZE";
+const LABEL_DIRECTORY: &str =  "LABEL.DIRECTORY";
+
+const LABEL_STREAM: &str = "LABEL.STREAM";
+const LABEL_RETRY: &str = "LABEL.RETRY";
+const LABEL_THROTTLE: &str = "LABEL.THROTTLE";
+const LABEL_GRACE_PERIOD_MILLIS: &str = "LABEL.GRACE_PERIOD_MILLIS";
+const LABEL_GRACE_PERIOD_TIMEOUT_SECS: &str = "LABEL.GRACE_PERIOD_TIMEOUT_SECS";
+const LABEL_FORCED_RETRY_INTERVAL_SECS: &str = "LABEL.FORCED_RETRY_INTERVAL_SECS";
+const LABEL_THROTTLE_KBPS: &str = "LABEL.THROTTLE_KBPS";
+
+const LABEL_RATE_LIMIT: &str =  "LABEL.RATE_LIMIT";
+const LABEL_PERIOD_MILLIS: &str = "LABEL.PERIOD_MILLIS";
+const LABEL_BURST_SIZE: &str = "LABEL.BURST_SIZE";
+
+const LABEL_RESOURCE_REWRITE_DISABLED: &str = "LABEL.RESOURCE_REWRITE_DISABLED";
+const LABEL_DISABLE_REFERER_HEADER: &str = "LABEL.DISABLE_REFERER_HEADER";
+
+
 #[function_component]
 pub fn ReverseProxyConfigView() -> Html {
     let translate = use_translation();
@@ -14,18 +35,18 @@ pub fn ReverseProxyConfigView() -> Html {
         match config {
             Some(entry) => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.CACHE")}</h1>
-                { config_field_bool!(entry, translate.t("LABEL.ENABLED"), enabled) }
-                { config_field_optional!(entry, translate.t("LABEL.SIZE"), size) }
-                { config_field_optional!(entry, translate.t("LABEL.DIRECTORY"), dir) }
+                <h1>{translate.t(LABEL_CACHE)}</h1>
+                { config_field_bool!(entry, translate.t(LABEL_ENABLED), enabled) }
+                { config_field_optional!(entry, translate.t(LABEL_SIZE), size) }
+                { config_field_optional!(entry, translate.t(LABEL_DIRECTORY), dir) }
             </Card>
             },
             None => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.CACHE")}</h1>
-                { config_field_empty!(translate.t("LABEL.ENABLED")) }
-                { config_field_empty!(translate.t("LABEL.SIZE")) }
-                { config_field_empty!(translate.t("LABEL.DIRECTORY")) }
+                <h1>{translate.t(LABEL_CACHE)}</h1>
+                { config_field_empty!(translate.t(LABEL_ENABLED)) }
+                { config_field_empty!(translate.t(LABEL_SIZE)) }
+                { config_field_empty!(translate.t(LABEL_DIRECTORY)) }
             </Card>
           },
         }
@@ -35,24 +56,24 @@ pub fn ReverseProxyConfigView() -> Html {
         match config {
             Some(entry) => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.STREAM")}</h1>
-                { config_field_bool!(entry, translate.t("LABEL.RETRY"), retry) }
-                { config_field_optional!(entry, translate.t("LABEL.THROTTLE"), throttle) }
-                { config_field!(entry, translate.t("LABEL.GRACE_PERIOD_MILLIS"), grace_period_millis) }
-                { config_field!(entry, translate.t("LABEL.GRACE_PERIOD_TIMEOUT_SECS"), grace_period_timeout_secs) }
-                { config_field!(entry, translate.t("LABEL.FORCED_RETRY_INTERVAL_SECS"), forced_retry_interval_secs) }
-                { config_field!(entry, translate.t("LABEL.THROTTLE_KBPS"), throttle_kbps) }
+                <h1>{translate.t(LABEL_STREAM)}</h1>
+                { config_field_bool!(entry, translate.t(LABEL_RETRY), retry) }
+                { config_field_optional!(entry, translate.t(LABEL_THROTTLE), throttle) }
+                { config_field!(entry, translate.t(LABEL_GRACE_PERIOD_MILLIS), grace_period_millis) }
+                { config_field!(entry, translate.t(LABEL_GRACE_PERIOD_TIMEOUT_SECS), grace_period_timeout_secs) }
+                { config_field!(entry, translate.t(LABEL_FORCED_RETRY_INTERVAL_SECS), forced_retry_interval_secs) }
+                { config_field!(entry, translate.t(LABEL_THROTTLE_KBPS), throttle_kbps) }
             </Card>
             },
             None => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.STREAM")}</h1>
-                { config_field_empty!(translate.t("LABEL.RETRY")) }
-                { config_field_empty!(translate.t("LABEL.THROTTLE")) }
-                { config_field_empty!(translate.t("LABEL.GRACE_PERIOD_MILLIS")) }
-                { config_field_empty!(translate.t("LABEL.GRACE_PERIOD_TIMEOUT_SECS")) }
-                { config_field_empty!(translate.t("LABEL.FORCED_RETRY_INTERVAL_SECS")) }
-                { config_field_empty!(translate.t("LABEL.THROTTLE_KBPS")) }
+                <h1>{translate.t(LABEL_STREAM)}</h1>
+                { config_field_empty!(translate.t(LABEL_RETRY)) }
+                { config_field_empty!(translate.t(LABEL_THROTTLE)) }
+                { config_field_empty!(translate.t(LABEL_GRACE_PERIOD_MILLIS)) }
+                { config_field_empty!(translate.t(LABEL_GRACE_PERIOD_TIMEOUT_SECS)) }
+                { config_field_empty!(translate.t(LABEL_FORCED_RETRY_INTERVAL_SECS)) }
+                { config_field_empty!(translate.t(LABEL_THROTTLE_KBPS)) }
             </Card>
           },
         }
@@ -62,18 +83,18 @@ pub fn ReverseProxyConfigView() -> Html {
         match config {
             Some(entry) => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.RATE_LIMIT")}</h1>
-                { config_field_bool!(entry, translate.t("LABEL.ENABLED"), enabled) }
-                { config_field!(entry, translate.t("LABEL.PERIOD_MILLIS"), period_millis) }
-                { config_field!(entry, translate.t("LABEL.BURST_SIZE"), burst_size) }
+                <h1>{translate.t(LABEL_RATE_LIMIT)}</h1>
+                { config_field_bool!(entry, translate.t(LABEL_ENABLED), enabled) }
+                { config_field!(entry, translate.t(LABEL_PERIOD_MILLIS), period_millis) }
+                { config_field!(entry, translate.t(LABEL_BURST_SIZE), burst_size) }
             </Card>
             },
             None => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.RATE_LIMIT")}</h1>
-                { config_field_empty!(translate.t("LABEL.ENABLED")) }
-                { config_field_empty!(translate.t("LABEL.PERIOD_MILLIS")) }
-                { config_field_empty!(translate.t("LABEL.BURST_SIZE")) }
+                <h1>{translate.t(LABEL_RATE_LIMIT)}</h1>
+                { config_field_empty!(translate.t(LABEL_ENABLED)) }
+                { config_field_empty!(translate.t(LABEL_PERIOD_MILLIS)) }
+                { config_field_empty!(translate.t(LABEL_BURST_SIZE)) }
             </Card>
           },
         }
@@ -83,8 +104,8 @@ pub fn ReverseProxyConfigView() -> Html {
         html! {
           <>
             <div class="tp__reverse-proxy-config-view__header tp__config-view-page__header">
-              { config_field_bool_empty!(translate.t("LABEL.RESOURCE_REWRITE_DISABLED")) }
-              { config_field_bool_empty!(translate.t("LABEL.DISABLE_REFERER_HEADER")) }
+              { config_field_bool_empty!(translate.t(LABEL_RESOURCE_REWRITE_DISABLED)) }
+              { config_field_bool_empty!(translate.t(LABEL_DISABLE_REFERER_HEADER)) }
             </div>
             <div class="tp__reverse-proxy-config-view__body tp__config-view-page__body">
              {render_cache(None)}
@@ -103,8 +124,8 @@ pub fn ReverseProxyConfigView() -> Html {
                         html! {
                         <>
                           <div class="tp__reverse-proxy-config-view__header tp__config-view-page__header">
-                            { config_field_bool!(reverse_proxy, translate.t("LABEL.RESOURCE_REWRITE_DISABLED"), resource_rewrite_disabled) }
-                            { config_field_bool!(reverse_proxy, translate.t("LABEL.DISABLE_REFERER_HEADER"), disable_referer_header) }
+                            { config_field_bool!(reverse_proxy, translate.t(LABEL_RESOURCE_REWRITE_DISABLED), resource_rewrite_disabled) }
+                            { config_field_bool!(reverse_proxy, translate.t(LABEL_DISABLE_REFERER_HEADER), disable_referer_header) }
                           </div>
                           <div class="tp__reverse-proxy-config-view__body tp__config-view-page__body">
                             { render_cache(reverse_proxy.cache.as_ref()) }

--- a/frontend/src/app/components/config/schedules_config_view.rs
+++ b/frontend/src/app/components/config/schedules_config_view.rs
@@ -22,14 +22,14 @@ pub fn SchedulesConfigView() -> Html {
                                         { config_field!(entry, translate.t("LABEL.SCHEDULE"), schedule) }
                                         { config_field_child!(translate.t("LABEL.TARGETS"), {
                                            html! { <div class="tp__config-view__tags">
+                                                <Chip label={translate.t("LABEL.ALL")} />
                                               { match entry.targets.as_ref() {
-                                                None => html! { <Chip label={translate.t("LABEL.ALL")} /> },
-                                                Some(targets) => if targets.is_empty() {
-                                                    html! { <Chip label={translate.t("LABEL.ALL")} /> }
-                                                } else {
-                                                    html! { for targets.iter().map(|t| html! { <Chip label={t.clone()} /> }) }
+                                                    Some(targets) if !targets.is_empty() => html! {
+                                                        for targets.iter().map(|t| html! { <Chip label={t.clone()} /> })
+                                                    },
+                                                    _ => html! {},
                                                 }
-                                             }}
+                                              }
                                           </div> }
                                         })}
                                      </div>

--- a/frontend/src/app/components/config/video_config_view.rs
+++ b/frontend/src/app/components/config/video_config_view.rs
@@ -5,6 +5,14 @@ use shared::model::VideoDownloadConfigDto;
 use yew::prelude::*;
 use yew_i18n::use_translation;
 
+const LABEL_DOWNLOAD: &str = "LABEL.DOWNLOAD";
+const LABEL_ORGANIZE_INTO_DIRECTORIES: &str = "LABEL.ORGANIZE_INTO_DIRECTORIES";
+const LABEL_DIRECTORY: &str = "LABEL.DIRECTORY";
+const LABEL_EPISODE_PATTERN: &str = "LABEL.EPISODE_PATTERN";
+const LABEL_HEADERS: &str = "LABEL.HEADERS";
+const LABEL_EXTENSIONS: &str = "LABEL.EXTENSIONS";
+const LABEL_WEB_SEARCH: &str = "LABEL.WEB_SEARCH";
+
 #[function_component]
 pub fn VideoConfigView() -> Html {
     let translate = use_translation();
@@ -12,7 +20,7 @@ pub fn VideoConfigView() -> Html {
 
     let render_extensions = |extensions: &Vec<String>| html! {
         <Card>
-        { config_field_child!(translate.t("LABEL.EXTENSIONS"), {
+        { config_field_child!(translate.t(LABEL_EXTENSIONS), {
            html! {
              <div class="tp__config-view__tags">
              {
@@ -27,11 +35,11 @@ pub fn VideoConfigView() -> Html {
         match download {
             Some(entry) => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.DOWNLOAD")}</h1>
-                { config_field_bool!(entry, translate.t("LABEL.ORGANIZE_INTO_DIRECTORIES"), organize_into_directories) }
-                { config_field_optional!(entry, translate.t("LABEL.DIRECTORY"), directory) }
-                { config_field_optional!(entry, translate.t("LABEL.EPISODE_PATTERN"), episode_pattern) }
-                { config_field_child!(translate.t("LABEL.HEADERS"), {
+                <h1>{translate.t(LABEL_DOWNLOAD)}</h1>
+                { config_field_bool!(entry, translate.t(LABEL_ORGANIZE_INTO_DIRECTORIES), organize_into_directories) }
+                { config_field_optional!(entry, translate.t(LABEL_DIRECTORY), directory) }
+                { config_field_optional!(entry, translate.t(LABEL_EPISODE_PATTERN), episode_pattern) }
+                { config_field_child!(translate.t(LABEL_HEADERS), {
                     html! {
                         <div class="tp__config-view__tags">
                           <ul>
@@ -54,11 +62,11 @@ pub fn VideoConfigView() -> Html {
             },
             None => html! {
             <Card class="tp__config-view__card">
-                <h1>{translate.t("LABEL.DOWNLOAD")}</h1>
-                { config_field_empty!(translate.t("LABEL.ORGANIZE_INTO_DIRECTORIES")) }
-                { config_field_empty!(translate.t("LABEL.DIRECTORY")) }
-                { config_field_empty!(translate.t("LABEL.EPISODE_PATTERN")) }
-                { config_field_empty!(translate.t("LABEL.HEADERS")) }
+                <h1>{translate.t(LABEL_DOWNLOAD)}</h1>
+                { config_field_empty!(translate.t(LABEL_ORGANIZE_INTO_DIRECTORIES)) }
+                { config_field_empty!(translate.t(LABEL_DIRECTORY)) }
+                { config_field_empty!(translate.t(LABEL_EPISODE_PATTERN)) }
+                { config_field_empty!(translate.t(LABEL_HEADERS)) }
             </Card>
           },
         }
@@ -68,10 +76,10 @@ pub fn VideoConfigView() -> Html {
         html! {
          <>
           <div class="tp__video-config-config-view__body tp__config-view-page__header">
-            { config_field_empty!(translate.t("LABEL.WEB_SEARCH")) }
+            { config_field_empty!(translate.t(LABEL_WEB_SEARCH)) }
           </div>
           <div class="tp__video-config-config-view__body tp__config-view-page__body">
-            { config_field_empty!(translate.t("LABEL.EXTENSIONS")) }
+            { config_field_empty!(translate.t(LABEL_EXTENSIONS)) }
             { render_download(None) }
           </div>
          </>
@@ -86,7 +94,7 @@ pub fn VideoConfigView() -> Html {
                         html! {
                           <>
                             <div class="tp__video-config-view__body tp__config-view-page__body">
-                              { config_field_optional!(video, translate.t("LABEL.WEB_SEARCH"), web_search) }
+                              { config_field_optional!(video, translate.t(LABEL_WEB_SEARCH), web_search) }
                             </div>
                             <div class="tp__video-config-view__body tp__config-view-page__body">
                             { render_extensions(&video.extensions) }

--- a/frontend/src/app/components/config/webui_config_view.rs
+++ b/frontend/src/app/components/config/webui_config_view.rs
@@ -7,6 +7,18 @@ use crate::{
 use yew::prelude::*;
 use yew_i18n::use_translation;
 
+const LABEL_AUTH: &str = "LABEL.AUTH";
+const LABEL_ENABLED: &str = "LABEL.ENABLED";
+const LABEL_ISSUER: &str = "LABEL.ISSUER";
+const LABEL_SECRET: &str = "LABEL.SECRET";
+const LABEL_TOKEN_TTL_MINS: &str = "LABEL.TOKEN_TTL_MINS";
+const LABEL_USERFILE: &str = "LABEL.USERFILE";
+const LABEL_PLAYER_SERVER: &str = "LABEL.PLAYER_SERVER";
+const LABEL_USER_UI_ENABLED: &str = "LABEL.USER_UI_ENABLED";
+const LABEL_CONTENT_SECURITY_POLICY: &str = "LABEL.CONTENT_SECURITY_POLICY";
+const LABEL_PATH: &str = "LABEL.PATH";
+
+
 #[function_component]
 pub fn WebUiConfigView() -> Html {
     let translate = use_translation();
@@ -15,12 +27,12 @@ pub fn WebUiConfigView() -> Html {
     let render_empty_auth = || {
         html! {
         <Card>
-            <h1>{translate.t("LABEL.AUTH")}</h1>
-                { config_field_empty!(translate.t("LABEL.ENABLED")) }
-                { config_field_empty!(translate.t("LABEL.ISSUER")) }
-                { config_field_empty!(translate.t("LABEL.SECRET")) }
-                { config_field_empty!(translate.t("LABEL.TOKEN_TTL_MINS")) }
-                { config_field_empty!(translate.t("LABEL.USERFILE")) }
+            <h1>{translate.t(LABEL_AUTH)}</h1>
+                { config_field_empty!(translate.t(LABEL_ENABLED)) }
+                { config_field_empty!(translate.t(LABEL_ISSUER)) }
+                { config_field_empty!(translate.t(LABEL_SECRET)) }
+                { config_field_empty!(translate.t(LABEL_TOKEN_TTL_MINS)) }
+                { config_field_empty!(translate.t(LABEL_USERFILE)) }
         </Card>
         }
     };
@@ -28,11 +40,11 @@ pub fn WebUiConfigView() -> Html {
     let render_empty = || {
         html! {
            <>
-            { config_field_bool_empty!(translate.t("LABEL.ENABLED")) }
-            { config_field_bool_empty!(translate.t("LABEL.USER_UI_ENABLED")) }
-            { config_field_bool_empty!(translate.t("LABEL.CONTENT_SECURITY_POLICY")) }
-            { config_field_empty!(translate.t("LABEL.PATH")) }
-            { config_field_empty!(translate.t("LABEL.PLAYER_SERVER")) }
+            { config_field_bool_empty!(translate.t(LABEL_ENABLED)) }
+            { config_field_bool_empty!(translate.t(LABEL_USER_UI_ENABLED)) }
+            { config_field_bool_empty!(translate.t(LABEL_CONTENT_SECURITY_POLICY)) }
+            { config_field_empty!(translate.t(LABEL_PATH)) }
+            { config_field_empty!(translate.t(LABEL_PLAYER_SERVER)) }
             { render_empty_auth()}
             </>
         }
@@ -46,22 +58,22 @@ pub fn WebUiConfigView() -> Html {
                     if let Some(web_ui) = &config.config.web_ui {
                         html! {
                         <>
-                            { config_field_bool!(web_ui, translate.t("LABEL.ENABLED"), enabled) }
-                            { config_field_bool!(web_ui, translate.t("LABEL.USER_UI_ENABLED"), user_ui_enabled) }
-                            { config_field_bool!(web_ui, translate.t("LABEL.CONTENT_SECURITY_POLICY"), content_security_policy) }
-                            { config_field_optional!(web_ui, translate.t("LABEL.PATH"), path) }
-                            { config_field_optional!(web_ui, translate.t("LABEL.PLAYER_SERVER"), player_server) }
+                            { config_field_bool!(web_ui, translate.t(LABEL_ENABLED), enabled) }
+                            { config_field_bool!(web_ui, translate.t(LABEL_USER_UI_ENABLED), user_ui_enabled) }
+                            { config_field_bool!(web_ui, translate.t(LABEL_CONTENT_SECURITY_POLICY), content_security_policy) }
+                            { config_field_optional!(web_ui, translate.t(LABEL_PATH), path) }
+                            { config_field_optional!(web_ui, translate.t(LABEL_PLAYER_SERVER), player_server) }
                             <Card>
-                              <h1>{translate.t("LABEL.AUTH")}</h1>
+                              <h1>{translate.t(LABEL_AUTH)}</h1>
                               {
                                 match web_ui.auth.as_ref() {
                                     Some(auth) => html!{
                                         <>
-                                        { config_field_bool!(auth, translate.t("LABEL.ENABLED"), enabled) }
-                                        { config_field!(auth, translate.t("LABEL.ISSUER"), issuer) }
-                                        { config_field_hide!(auth, translate.t("LABEL.SECRET"), secret) }
-                                        { config_field!(auth, translate.t("LABEL.TOKEN_TTL_MINS"), token_ttl_mins) }
-                                        { config_field_optional!(auth, translate.t("LABEL.USERFILE"), userfile) }
+                                        { config_field_bool!(auth, translate.t(LABEL_ENABLED), enabled) }
+                                        { config_field!(auth, translate.t(LABEL_ISSUER), issuer) }
+                                        { config_field_hide!(auth, translate.t(LABEL_SECRET), secret) }
+                                        { config_field!(auth, translate.t(LABEL_TOKEN_TTL_MINS), token_ttl_mins) }
+                                        { config_field_optional!(auth, translate.t(LABEL_USERFILE), userfile) }
                                         </>
                                     },
                                     None => render_empty_auth(),

--- a/frontend/src/app/components/playlist/playlist_explorer_view.rs
+++ b/frontend/src/app/components/playlist/playlist_explorer_view.rs
@@ -3,7 +3,7 @@ use crate::app::context::PlaylistExplorerContext;
 use std::rc::Rc;
 use yew::prelude::*;
 use yew_i18n::use_translation;
-use shared::model::{PlaylistRequestType, UiPlaylistCategories};
+use shared::model::{PlaylistRequest, UiPlaylistCategories};
 use crate::app::components::playlist::playlist_explorer::PlaylistExplorer;
 
 #[function_component]
@@ -12,7 +12,7 @@ pub fn PlaylistExplorerView() -> Html {
     let breadcrumbs = use_state(|| Rc::new(vec![translate.t("LABEL.PLAYLISTS"), translate.t("LABEL.LIST")]));
     let active_page = use_state(|| PlaylistExplorerPage::SourceSelector);
     let playlist = use_state(|| None::<Rc<UiPlaylistCategories>>);
-    let playlist_req_type = use_state(|| None::<PlaylistRequestType>);
+    let playlist_req = use_state(|| None::<PlaylistRequest>);
 
     let handle_breadcrumb_select = {
         let view_visible = active_page.clone();
@@ -39,7 +39,7 @@ pub fn PlaylistExplorerView() -> Html {
     let context = PlaylistExplorerContext {
         active_page: active_page.clone(),
         playlist: playlist.clone(),
-        playlist_request_type: playlist_req_type.clone(),
+        playlist_request: playlist_req.clone(),
     };
 
     html! {

--- a/frontend/src/app/components/playlist/source_selector.rs
+++ b/frontend/src/app/components/playlist/source_selector.rs
@@ -45,12 +45,11 @@ pub fn PlaylistSourceSelector() -> Html {
                 set_loading.set(true);
                 services.event.broadcast(EventMessage::Busy(BusyStatus::Show));
                 let set_loading = set_loading.clone();
-                let req_type = request.rtype;
                 let req = request;
                 spawn_local(async move {
                     let playlist = services.playlist.get_playlist_categories(&req).await;
                     playlist_explorer_ctx_clone.playlist.set(playlist);
-                    playlist_explorer_ctx_clone.playlist_request_type.set(Some(req_type));
+                    playlist_explorer_ctx_clone.playlist_request.set(Some(req));
                     set_loading.set(false);
                     services.event.broadcast(EventMessage::Busy(BusyStatus::Hide));
                 });

--- a/frontend/src/app/context.rs
+++ b/frontend/src/app/context.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 use regex::Regex;
 use yew::UseStateHandle;
-use shared::model::{AppConfigDto, ConfigTargetDto, PlaylistRequestType, ProxyUserCredentialsDto, SearchRequest, StatusCheck, UiPlaylistCategories};
+use shared::model::{AppConfigDto, ConfigTargetDto, PlaylistRequest, ProxyUserCredentialsDto, SearchRequest, StatusCheck, UiPlaylistCategories};
 use crate::app::components::{InputRow, PlaylistEditorPage, PlaylistExplorerPage, UserlistPage};
 
 type SingleSource = (Vec<Rc<InputRow>>, Vec<Rc<ConfigTargetDto>>);
@@ -20,7 +20,7 @@ pub struct PlaylistEditorContext {
 pub struct PlaylistExplorerContext {
     pub active_page: UseStateHandle<PlaylistExplorerPage>,
     pub playlist: UseStateHandle<Option<Rc<UiPlaylistCategories>>>,
-    pub playlist_request_type: UseStateHandle<Option<PlaylistRequestType>>,
+    pub playlist_request: UseStateHandle<Option<PlaylistRequest>>,
 }
 
 

--- a/frontend/src/app/mod.rs
+++ b/frontend/src/app/mod.rs
@@ -79,7 +79,7 @@ pub fn App() -> Html {
             let futures = languages.iter()
                 .map(|lang| async move {
                     let url = format!("assets/i18n/{lang}.json");
-                    let result: Result<Value, Error> = request_get(&url, None).await;
+                    let result: Result<Value, Error> = request_get(&url, None, None).await;
                     (lang.to_string(), result)
                 })
                 .collect::<Vec<_>>();
@@ -101,7 +101,7 @@ pub fn App() -> Html {
     {
         let config_state = configuration_state.clone();
         use_async_with_options::<_, (), Error>(async move {
-            match request_get("config.json", None).await {
+            match request_get("config.json", None, None).await {
                 Ok(cfg) => config_state.set(Some(cfg)),
                 Err(err) => error!("Failed to load config {err}"),
             }
@@ -112,7 +112,7 @@ pub fn App() -> Html {
     {
         let icon_state = icon_state.clone();
         use_async_with_options::<_, (), Error>(async move {
-            match request_get("assets/icons.json", None).await {
+            match request_get("assets/icons.json", None, None).await {
                 Ok(icons) => icon_state.set(Some(icons)),
                 Err(err) => error!("Failed to load icons {err}"),
             }

--- a/frontend/src/services/auth_service.rs
+++ b/frontend/src/services/auth_service.rs
@@ -49,7 +49,7 @@ impl AuthService {
             username,
             password,
         };
-        match request_post::<UserCredential, TokenResponse>(&concat_path(&self.auth_path, "token"), credentials, None).await {
+        match request_post::<UserCredential, TokenResponse>(&concat_path(&self.auth_path, "token"), credentials, None, None).await {
             Ok(token) => {
                 self.username.replace(token.username.to_string());
                 self.auth_channel.set(true);
@@ -66,7 +66,7 @@ impl AuthService {
     }
 
     pub async fn refresh(&self) -> Result<TokenResponse, Error> {
-        match request_post::<(), TokenResponse>(&concat_path(&self.auth_path, "refresh"), (), None).await {
+        match request_post::<(), TokenResponse>(&concat_path(&self.auth_path, "refresh"), (), None, None).await {
             Ok(token) => {
                 self.username.replace(token.username.to_string());
                 self.auth_channel.set(true);

--- a/frontend/src/services/config_service.rs
+++ b/frontend/src/services/config_service.rs
@@ -54,7 +54,7 @@ impl ConfigService {
         if self.is_fetching.swap(true, Ordering::SeqCst) {
             return;
         }
-        let result = match request_get::<AppConfigDto>(&self.config_path, None).await {
+        let result = match request_get::<AppConfigDto>(&self.config_path, None, None).await {
             Ok(mut app_config) => {
                 let templates = {
                     if let Some(templ) = app_config.sources.templates.as_mut() {
@@ -96,7 +96,7 @@ impl ConfigService {
     }
 
     pub async fn get_ip_info(&self) -> Option<IpCheckDto> {
-        match request_get::<IpCheckDto>(&self.ip_check_path, None).await {
+        match request_get::<IpCheckDto>(&self.ip_check_path, None, None).await {
             Ok(cfg) => Some(cfg),
             Err(err) => {
                 error!("{err}");
@@ -108,7 +108,7 @@ impl ConfigService {
     pub async fn get_batch_input_content(&self, input: &ConfigInputDto) -> Option<String> {
         let id = input.id.to_string();
         let path = concat_path(&self.batch_input_content_path, &id);
-        match request_get::<String>(&path, Some("text/plain".to_owned())).await {
+        match request_get::<String>(&path, None, Some("text/plain".to_owned())).await {
             Ok(cfg) => Some(cfg),
             Err(err) => {
                 error!("{err}");

--- a/frontend/src/services/playlist_service.rs
+++ b/frontend/src/services/playlist_service.rs
@@ -1,12 +1,13 @@
 use crate::services::{get_base_href, request_post};
 use log::error;
-use shared::model::{PlaylistCategoriesResponse, PlaylistRequest, UiPlaylistCategories};
+use shared::model::{CommonPlaylistItem, PlaylistCategoriesResponse, PlaylistRequest, UiPlaylistCategories, WebplayerUrlRequest};
 use std::rc::Rc;
-use shared::utils::concat_path_leading_slash;
+use shared::utils::{concat_path_leading_slash};
 
 pub struct PlaylistService {
     target_update_api_path: String,
     playlist_api_path: String,
+    playlist_api_webplayer_url_path: String,
 }
 impl Default for PlaylistService {
     fn default() -> Self {
@@ -20,19 +21,35 @@ impl PlaylistService {
         Self {
             target_update_api_path: concat_path_leading_slash(&base_href, "api/v1/playlist/update"),
             playlist_api_path: concat_path_leading_slash(&base_href, "api/v1/playlist"),
+            playlist_api_webplayer_url_path: concat_path_leading_slash(&base_href, "api/v1/playlist/webplayer"),
         }
     }
     pub async fn update_targets(&self, targets: &[&str]) -> bool {
-        request_post::<&[&str], ()>(&self.target_update_api_path, targets, None).await.map_or_else(|err| {
+        request_post::<&[&str], ()>(&self.target_update_api_path, targets, None, None).await.map_or_else(|err| {
             error!("{err}");
             false
         }, |_| true)
     }
 
     pub async fn get_playlist_categories(&self, playlist_request: &PlaylistRequest) -> Option<Rc<UiPlaylistCategories>> {
-        request_post::<&PlaylistRequest, PlaylistCategoriesResponse>(&self.playlist_api_path, playlist_request, None).await.map_or_else(|err| {
+        request_post::<&PlaylistRequest, PlaylistCategoriesResponse>(&self.playlist_api_path, playlist_request, None, None).await.map_or_else(|err| {
             error!("{err}");
             None
         }, |response| Some(Rc::new(response.into())))
+    }
+
+    pub async fn get_playlist_webplayer_url(&self, target_id: u16, dto: &Rc<CommonPlaylistItem>) -> Option<String> {
+        let request = WebplayerUrlRequest {
+            target_id,
+            virtual_id: dto.virtual_id,
+            cluster: dto.xtream_cluster.unwrap_or_default(),
+        };
+        match request_post::<&WebplayerUrlRequest, String>(&self.playlist_api_webplayer_url_path, &request, None, Some("text/plain".to_string())).await {
+            Ok(content) => Some(content),
+            Err(err) => {
+                error!("{err}");
+                None
+            }
+        }
     }
 }

--- a/frontend/src/services/requests.rs
+++ b/frontend/src/services/requests.rs
@@ -30,12 +30,13 @@ pub fn set_token(token: Option<&str>) {
 }
 
 /// build all kinds of http request: post/get/delete etc.
-async fn request<B, T>(method: RequestMethod, url: &str, body: B, content_type: Option<String>) -> Result<T, Error>
+async fn request<B, T>(method: RequestMethod, url: &str, body: B, content_type: Option<String>, response_type: Option<String>) -> Result<T, Error>
 where
     T: DeserializeOwned + 'static + std::fmt::Debug,
     B: Serialize + std::fmt::Debug,
 {
     let c_type = content_type.as_ref().map_or("application/json", |c| c.as_str());
+    let r_type = response_type.as_ref().map_or("application/json", |c| c.as_str());
     let mut request = match method {
         RequestMethod::Get => Request::get(url),
         RequestMethod::Post => Request::post(url).body(serde_json::to_string(&body).unwrap()),
@@ -50,7 +51,7 @@ where
         Ok(response) => {
             match response.status() {
                 200 => {
-                    if c_type.eq("application/json") {
+                    if r_type.eq("application/json") {
                         if std::any::TypeId::of::<T>() == std::any::TypeId::of::<()>() {
                             // `T = ()` valid
                             let _ = response.text().await;
@@ -98,19 +99,19 @@ where
 }
 
 /// Delete request
-pub async fn request_delete<T>(url: &str, content_type: Option<String>) -> Result<T, Error>
+pub async fn request_delete<T>(url: &str, content_type: Option<String>, response_type: Option<String>) -> Result<T, Error>
 where
     T: DeserializeOwned + 'static + std::fmt::Debug,
 {
-    request(RequestMethod::Delete, url, (), content_type).await
+    request(RequestMethod::Delete, url, (), content_type, response_type).await
 }
 
 /// Get request
-pub async fn request_get<T>(url: &str, content_type: Option<String>) -> Result<T, Error>
+pub async fn request_get<T>(url: &str, content_type: Option<String>, response_type: Option<String>) -> Result<T, Error>
 where
     T: DeserializeOwned + 'static + std::fmt::Debug,
 {
-    request(RequestMethod::Get, url, (), content_type).await
+    request(RequestMethod::Get, url, (), content_type, response_type).await
 }
 
 // pub async fn request_get_api<T>(url: &str) -> Result<T, Error>
@@ -121,21 +122,21 @@ where
 // }
 
 /// Post request with a body
-pub async fn request_post<B, T>(url: &str, body: B, content_type: Option<String>) -> Result<T, Error>
+pub async fn request_post<B, T>(url: &str, body: B, content_type: Option<String>, response_type: Option<String>) -> Result<T, Error>
 where
     T: DeserializeOwned + 'static + std::fmt::Debug,
     B: Serialize + std::fmt::Debug,
 {
-    request(RequestMethod::Post, url, body, content_type).await
+    request(RequestMethod::Post, url, body, content_type, response_type).await
 }
 
 /// Put request with a body
-pub async fn request_put<B, T>(url: &str, body: B, content_type: Option<String>) -> Result<T, Error>
+pub async fn request_put<B, T>(url: &str, body: B, content_type: Option<String>, response_type: Option<String>) -> Result<T, Error>
 where
     T: DeserializeOwned + 'static + std::fmt::Debug,
     B: Serialize + std::fmt::Debug,
 {
-    request(RequestMethod::Put, url, body, content_type).await
+    request(RequestMethod::Put, url, body, content_type, response_type).await
 }
 
 /// Set limit for pagination

--- a/frontend/src/services/status_service.rs
+++ b/frontend/src/services/status_service.rs
@@ -22,6 +22,6 @@ impl StatusService {
     }
 
     pub async fn get_server_status(&self) -> Result<Rc<StatusCheck>, crate::error::Error> {
-        request_get::<Rc<StatusCheck>>(&self.status_path, None).await
+        request_get::<Rc<StatusCheck>>(&self.status_path, None, None).await
     }
 }

--- a/shared/src/model/mod.rs
+++ b/shared/src/model/mod.rs
@@ -15,6 +15,7 @@ mod web_socket;
 mod playlist_request;
 mod playlist_categories;
 mod search_request;
+mod webplayer_url_request;
 
 pub use self::cluster_flags::*;
 pub use self::playlist::*;
@@ -32,3 +33,4 @@ pub use self::web_socket::*;
 pub use self::playlist_request::*;
 pub use self::playlist_categories::*;
 pub use self::search_request::*;
+pub use self::webplayer_url_request::*;

--- a/shared/src/model/playlist_request.rs
+++ b/shared/src/model/playlist_request.rs
@@ -12,7 +12,7 @@ pub enum PlaylistRequestType {
     M3U
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct PlaylistRequest {
     pub rtype: PlaylistRequestType,
     pub username: Option<String>,

--- a/shared/src/model/webplayer_url_request.rs
+++ b/shared/src/model/webplayer_url_request.rs
@@ -1,0 +1,9 @@
+use serde::{Deserialize, Serialize};
+use crate::model::XtreamCluster;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WebplayerUrlRequest {
+    pub target_id: u16,
+    pub virtual_id: u32,
+    pub cluster: XtreamCluster,
+}


### PR DESCRIPTION
Copy WebPlayerUrl added for playlist explorer
Config View refactorings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Playlist: Added “Copy Webplayer URL” action alongside “Copy Virtual ID” and “Copy Provider URL,” with a toast indicating the URL is valid for 30 seconds.

- UI/UX
  - Config pages now show placeholder fields when data is unavailable instead of an empty state.
  - Schedules always display an “ALL” chip in Targets.

- Internationalization
  - Updated copy-action labels; added a message for Webplayer URL validity.

- Style
  - Config layout made more consistent: configurable grid widths, max-width caps, improved alignment, and removed trailing label colons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->