### PR TITLE
PlaylistExplorer search Result returns now the groups instead of flat…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added TimeZone to `epg_timeshift: [-+]hh:mm or TimeZone`, example `Europe/Paris`, `America/New_York`, `-2:30`(-2h30m), `+0:15` (15m), `2` (2h), `:30` (30m), `:3` (3m)
 If you use TimeZone the timeshift will change on Summer/Winter time if its applied in the TZ.
 - Fixed: Mappings now automatically reload and reapply after configuration changes, preventing stale settings.
+- Search in Playlist Explorer now returns groups instead of matching flat channel list.
 
 # 3.1.7 (2025-10-10)
 - Added Dark/Bright theme switch

--- a/README.md
+++ b/README.md
@@ -1144,7 +1144,7 @@ It is whitespace-tolerant and uses familiar programming concepts with a custom s
 - Strings / Text: Enclosed in double quotes. "example string" 
 - Null value `null`
 - Regex Matching:   `@FieldName ~ "Regex"` like in filter statements. You can match a `FieldName` or a existing `variable`.
-- Access a field in a regex match result:  with `result.capture`. For example, if you have multiple captures you can access them by their name, or their index beginning at 1.
+- Access a field in a regex match result:  with `result.capture`. For example, if you have multiple captures you can access them by their name, or their index beginning at `1` like `result.1`, `result.2`.
 - Builtin functions: 
   - concat(a, b, ...)
   - uppercase(a)


### PR DESCRIPTION
PlaylistExplorer search Result returns now the groups instead of flat channel list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Playlist Explorer search now returns grouped results, preserving group titles and showing only matching channels within each group.
  * Regex-based search also returns grouped results, omitting groups with no matches.

* Documentation
  * Updated regex match access examples to use literal index syntax (e.g., result.1, result.2).
  * Expanded DSL built-in functions list: lowercase, capitalize, trim, number, print, first, template, replace.
  * Clarified available field names and provided additional examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->