### PR TITLE
Update playlist cache on hot_reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1462,7 +1462,6 @@ Now you can do `nginx`  configuration like
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-NginX-Proxy true;
       proxy_pass http://192.169.1.9:8901/;
-      proxy_ssl_session_reuse off;
       proxy_set_header Host $http_host;
       proxy_redirect off;
       proxy_buffering off;

--- a/backend/src/api/endpoints/hls_api.rs
+++ b/backend/src/api/endpoints/hls_api.rs
@@ -137,10 +137,11 @@ pub(in crate::api) async fn handle_hls_stream_request(
 
                 let playlist = format!(r"#EXTM3U
 #EXT-X-VERSION:3
-#EXT-X-TARGETDURATION:3600
+#EXT-X-TARGETDURATION:30
 #EXT-X-MEDIA-SEQUENCE:0
-#EXTINF:3600.0,
+#EXTINF:30.0,
 {url}
+#EXT-X-ENDLIST
 ");
                 hls_response(playlist.to_string()).into_response()
             } else {

--- a/backend/src/api/model/mod.rs
+++ b/backend/src/api/model/mod.rs
@@ -10,8 +10,10 @@ mod active_provider_manager;
 mod stream;
 mod provider_config;
 mod event_manager;
+mod playlist_mem_cache;
 
 pub use self::app_state::*;
+pub use self::playlist_mem_cache::*;
 pub(in crate::api) use self::request::*;
 pub(in crate::api) use self::download::*;
 pub(in crate::api) use self::xtream::*;

--- a/backend/src/api/model/playlist_mem_cache.rs
+++ b/backend/src/api/model/playlist_mem_cache.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+use tokio::sync::RwLock;
+use shared::model::{M3uPlaylistItem, XtreamPlaylistItem};
+use crate::repository::bplustree::BPlusTree;
+use crate::repository::target_id_mapping::VirtualIdRecord;
+
+pub struct PlaylistXtreamStorage {
+    pub id_mapping: BPlusTree<u32, VirtualIdRecord>,
+    pub live: BPlusTree<u32, XtreamPlaylistItem>,
+    pub vod: BPlusTree<u32, XtreamPlaylistItem>,
+    pub series: BPlusTree<u32, XtreamPlaylistItem>,
+}
+
+pub type PlaylistM3uStorage = BPlusTree<u32, M3uPlaylistItem>;
+
+pub enum PlaylistStorage {
+    M3uPlaylist(Box<PlaylistM3uStorage>),
+    XtreamPlaylist(Box<PlaylistXtreamStorage>),
+}
+
+pub struct TargetPlaylistStorage {
+    pub xtream: Option<PlaylistXtreamStorage>,
+    pub m3u: Option<PlaylistM3uStorage>,
+}
+
+pub type TargetPlaylistStorageMap = HashMap<String, TargetPlaylistStorage>;
+
+pub struct PlaylistStorageState {
+    pub data: RwLock<TargetPlaylistStorageMap>,
+}
+
+impl PlaylistStorageState {
+
+    pub(crate) fn new() -> Self {
+        Self {
+            data: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub async fn cache_playlist(&self, target_name: &str, playlist: PlaylistStorage) {
+        match playlist {
+            PlaylistStorage::M3uPlaylist(m3u_playlist) => {
+                match self.data.write().await.entry(target_name.to_string()) {
+                    std::collections::hash_map::Entry::Occupied(mut entry) => {
+                        let storage = entry.get_mut();
+                        storage.m3u = Some(*m3u_playlist);
+                    }
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        entry.insert(TargetPlaylistStorage {
+                            xtream: None,
+                            m3u: Some(*m3u_playlist),
+                        });
+                    }
+                }
+            }
+            PlaylistStorage::XtreamPlaylist(xtream_playlist) => {
+                match self.data.write().await.entry(target_name.to_string()) {
+                    std::collections::hash_map::Entry::Occupied(mut entry) => {
+                        let storage = entry.get_mut();
+                        storage.xtream = Some(*xtream_playlist);
+                    }
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        entry.insert(TargetPlaylistStorage {
+                            xtream: Some(*xtream_playlist),
+                            m3u: None,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}

--- a/backend/src/api/model/streams/provider_stream.rs
+++ b/backend/src/api/model/streams/provider_stream.rs
@@ -1,5 +1,5 @@
 use crate::api::api_utils::{HeaderFilter};
-use crate::api::model::CustomVideoStream;
+use crate::api::model::{CustomVideoStream, ThrottledStream};
 use crate::model::{AppConfig};
 use shared::model::PlaylistItemType;
 use log::{trace};
@@ -71,7 +71,7 @@ fn create_video_stream(video_buffer: Option<&TransportStreamBuffer>, headers: &[
             .filter(|(key, _)| !(key.eq("content-type") || key.eq("content-length") || key.contains("range")))
             .map(|(key, value)| (key.clone(), value.clone())).collect();
         response_headers.push(("content-type".to_string(), "video/mp2t".to_string()));
-        (Some(Box::pin(CustomVideoStream::new(video.clone()))), Some((response_headers, StatusCode::OK, None)))
+        (Some(Box::pin(ThrottledStream::new(CustomVideoStream::new(video.clone()), 8000))), Some((response_headers, StatusCode::OK, None)))
     } else {
         (None, None)
     }

--- a/backend/src/api/model/streams/transport_stream_buffer.rs
+++ b/backend/src/api/model/streams/transport_stream_buffer.rs
@@ -7,7 +7,7 @@ const MAX_PTS_DTS: u64 = 1 << 33;    // 33 bit PTS/DTS cycle
 
 const TS_PACKET_SIZE: usize = 188;
 const SYNC_BYTE: u8 = 0x47;
-const PACKET_COUNT: usize = 7;
+const PACKET_COUNT: usize = 250;
 const CHUNK_SIZE: usize = TS_PACKET_SIZE * PACKET_COUNT;
 
 const ADAPTATION_FIELD_FLAG_PCR: u8 = 0x10; // PCR flag bit in adaptation field flags

--- a/backend/src/model/config/source.rs
+++ b/backend/src/model/config/source.rs
@@ -85,7 +85,6 @@ impl SourcesConfig {
         None
     }
 
-
     /// Returns the targets that were specified as parameters.
     /// If invalid targets are found, the program will be terminated.
     /// The return value has `enabled` set to true, if selective targets should be processed, otherwise false.

--- a/backend/src/repository/playlist_repository.rs
+++ b/backend/src/repository/playlist_repository.rs
@@ -176,28 +176,33 @@ fn load_m3u_target_storage(app_config: &AppConfig, target: &ConfigTarget) -> Res
     Ok(tree)
 }
 
+
+
 pub async fn load_playlists_into_memory_cache(app_state: &AppState) -> Result<(), TuliproxError> {
-    let app_config: &AppConfig = &app_state.app_config;
     for sources in &app_state.app_config.sources.load().sources {
         for target in &sources.targets {
-            if target.use_memory_cache {
-                for output in &target.output {
-                    match output {
-                        TargetOutput::Xtream(_) => {
-                            if let Ok(storage) = load_xtream_target_storage(app_config, target) {
-                                app_state.cache_playlist(&target.name, PlaylistStorage::XtreamPlaylist(Box::new(storage))).await;
-                            }
-                        }
-                        TargetOutput::M3u(_) => {
-                            if let Ok(storage) = load_m3u_target_storage(app_config, target) {
-                                app_state.cache_playlist(&target.name, PlaylistStorage::M3uPlaylist(Box::new(storage))).await;
-                            }
-                        }
-                        _ => {}
-                    }
-                };
-            }
+            load_target_into_memory_cache(app_state, target).await;
         }
     }
     Ok(())
+}
+
+pub async fn load_target_into_memory_cache(app_state: &AppState, target: &Arc<ConfigTarget>) {
+    if target.use_memory_cache {
+        for output in &target.output {
+            match output {
+                TargetOutput::Xtream(_) => {
+                    if let Ok(storage) = load_xtream_target_storage(&app_state.app_config, target) {
+                        app_state.cache_playlist(&target.name, PlaylistStorage::XtreamPlaylist(Box::new(storage))).await;
+                    }
+                }
+                TargetOutput::M3u(_) => {
+                    if let Ok(storage) = load_m3u_target_storage(&app_state.app_config, target) {
+                        app_state.cache_playlist(&target.name, PlaylistStorage::M3uPlaylist(Box::new(storage))).await;
+                    }
+                }
+                _ => {}
+            }
+        };
+    }
 }


### PR DESCRIPTION
Update playlist cache on hot_reload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Reduced HLS channel unavailability timeout from 3600 to 30 seconds for faster failover detection.

* **Performance Improvements**
  * Added in-memory playlist caching for improved performance across multiple streams.
  * Increased transport stream packet processing per chunk for better throughput.
  * Implemented bandwidth throttling on video streams.

* **Documentation**
  * Updated nginx proxy configuration example.

* **Chores**
  * Minor code cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->