### PR TITLE
Rlease v3.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
-# 3.1.8 (2025-10-xx)
+# 3.1.8 (2025-11-18)
 - Fixed HLS streaming issues caused by session eviction and incorrect headers.
 - Catchup stream fix cycling through multiple providers on play.
+- Custom streams fix and update webui stream info
 - Added TimeZone to `epg_timeshift: [-+]hh:mm or TimeZone`, example `Europe/Paris`, `America/New_York`, `-2:30`(-2h30m), `+0:15` (15m), `2` (2h), `:30` (30m), `:3` (3m)
 If you use TimeZone the timeshift will change on Summer/Winter time if its applied in the TZ.
 - Fixed: Mappings now automatically reload and reapply after configuration changes, preventing stale settings.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "3.1.7"
+version = "3.1.8"
 dependencies = [
  "anyhow",
  "base64",
@@ -1120,9 +1120,9 @@ dependencies = [
  "futures-signals",
  "gloo-render 0.2.0",
  "gloo-storage 0.3.0",
- "gloo-timers 0.3.0",
+ "gloo-timers 0.2.6",
  "gloo-utils 0.2.0",
- "implicit-clone 0.6.0",
+ "implicit-clone",
  "js-sys",
  "log",
  "prost",
@@ -1633,6 +1633,8 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
 dependencies = [
+ "futures-channel",
+ "futures-core",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2167,15 +2169,6 @@ checksum = "f8a9aa791c7b5a71b636b7a68207fdebf171ddfc593d9c8506ec4cbc527b6a84"
 dependencies = [
  "implicit-clone-derive",
  "indexmap",
-]
-
-[[package]]
-name = "implicit-clone"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1689b939ee35e3a075b0834b5672efd43aec8a6e81a1c6002b76a5ca2f211ae0"
-dependencies = [
- "implicit-clone-derive",
 ]
 
 [[package]]
@@ -3801,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "3.1.7"
+version = "3.1.8"
 dependencies = [
  "base64",
  "bitflags 2.9.4",
@@ -4350,7 +4343,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tuliprox"
-version = "3.1.7"
+version = "3.1.8"
 dependencies = [
  "arc-swap",
  "async-compression",
@@ -5076,7 +5069,7 @@ dependencies = [
  "console_error_panic_hook",
  "futures",
  "gloo 0.10.0",
- "implicit-clone 0.4.9",
+ "implicit-clone",
  "indexmap",
  "js-sys",
  "prokio",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tuliprox"
-version = "3.1.7"
+version = "3.1.8"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "frontend"
-version = "3.1.7"
+version = "3.1.8"
 edition = "2021"
 
 [dependencies]
-shared = { version = "3.1.7", path = "../shared" }
+shared = { version = "3.1.8", path = "../shared" }
 chrono = "0"
 yew = "0.21"
 yew-router = "0.18"

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared"
-version = "3.1.7"
+version = "3.1.8"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# 3.1.8 (2025-11-18)
:zap:  !BREAKING_CHANGE! `disble_referer_header` is now part of `reverse_proxy.disabled_header` configuration
:lollipop: added `reverse_proxy.disabled_header` configuration
  Allows removing selected headers before forwarding requests when acting as a reverse proxy. Configure removal of the referer header, all `X-*` headers, and additional custom headers.
:lady_beetle: Fixed HLS streaming issues caused by session eviction and incorrect headers.
:lady_beetle: Catchup stream fix cycling through multiple providers on play.
:lady_beetle: Custom streams fix and update webui stream info
:lollipop: Added TimeZone to `epg_timeshift: [-+]hh:mm or TimeZone`, example `Europe/Paris`, `America/New_York`, `-2:30`(-2h30m), `+0:15` (15m), `2` (2h), `:30` (30m), `:3` (3m)
If you use TimeZone the timeshift will change on Summer/Winter time if its applied in the TZ.
:lady_beetle: Fixed: Mappings now automatically reload and reapply after configuration changes, preventing stale settings.
:lollipop: Search in Playlist Explorer now returns groups instead of matching flat channel list.
:lollipop: Added `use_memory_cache` attribute to target definition to hold playlist in memory to reduce disc access.
Placing playlist into memory causes more RAM usage but reduces disk access.
:lollipop: Added optional `filter` attribute to Output (except HDHomerun-Output). 
Output filters are applied after all transformations have been performed, therefore, all filter contents must refer to the final state of the playlist.
:lollipop: Added burst buffer to shared stream
:lollipop: Telegram message thread support. thread id can now be appended to chat-id like `chat-id:thread-id`.
:lollipop: Telegram supports markdown generation for structured json messages. simply set `markdown: true` in telegram config.
:lollipop: Added User-Stream-Connections Table to WebUI
:lollipop: Enhanced STRM output filenames to include detailed media quality info (e.g., 4K, HDR, x265, 5.1) for easy version distinction.
:lollipop: Added standardized SSDP (Simple Service Discovery Protocol) and the Proprietary HDHomeRun UDP Discovery Protocol (Port 65001)
:lady_beetle: Fixed some session handling issue
:lollipop: UserTable: Copy credentials to clipboard from user table
:lollipop: UserTable: Kick user action from streams table
:lollipop: UserTable: Auto-generated username/password for new proxy users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issues with custom streams
  * Updated web UI stream information display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->