### PR TITLE
Feature/provider linup manager deadlock fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Added **TMDB** settings (Rate Limit, Cache Duration, Language) and **Metadata Formats** (NFO support) to Library configuration UI.
 
 ## 🚀 Performance & Stability
+- **Deadlock Resolution**: Fixed a potential deadlock in `ProviderLineupManager::reconcile_connections` by refactoring `DashMap` iterations to use snapshots, preventing internal shard locks from being held during async lock acquisition.
 - **Connection Reconciliation & GC**: Resolved a critical issue where provider connection counters could leak or become stale during hot reloads. Added automatic garbage collection for unused provider records to prevent logical memory buildup.
 - **Full Async Runtime**: Transitioned to `#[tokio::main]` and async I/O throughout the entire application.
 - **Non-Blocking Operations**: Cache persistence, playlist exports, and config saves moved to async tasks to prevent runtime stalls.


### PR DESCRIPTION
Identified a critical deadlock path in reconcile_connections where a DashMap iterator held internal shard locks while awaiting an asynchronous

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Stability**
  * Resolved a potential deadlock condition in the provider connection management system that could occur during concurrent operations. This fix improves system stability and responsiveness, especially during periods of heavy concurrent activity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->