### PR TITLE
Disabled mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2441,16 +2441,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,15 +2536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -4646,7 +4627,6 @@ dependencies = [
  "lol_html",
  "lz4_flex",
  "memmap2",
- "mimalloc",
  "mime",
  "mime_guess",
  "notify",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -80,9 +80,8 @@ mime_guess = "2"
 libc = "0.2"
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["psapi", "minwindef", "processthreadsapi"] }
-[target.'cfg(target_os = "linux")'.dependencies]
-mimalloc = "0.1"
-
+#[target.'cfg(target_os = "linux")'.dependencies]
+#mimalloc = "0.1"
 #[target.'cfg(not(target_env = "msvc"))'.dependencies]
 #tikv-jemallocator =  "0.6"
 # tikv-jemallocator =  { version = "*", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -4,9 +4,9 @@
 #![allow(clippy::return_self_not_must_use)]
 #![allow(clippy::missing_errors_doc)]
 
-#[cfg(target_os = "linux")]
-#[global_allocator]
-static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+// #[cfg(target_os = "linux")]
+// #[global_allocator]
+// static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 // #[cfg(not(target_env = "msvc"))]
 // #[global_allocator]
 // static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;


### PR DESCRIPTION
Disabled mimalloc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the custom memory allocator optimization for Linux systems. The application will now use the default system allocator on Linux platforms instead of the previously configured alternative allocator.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->