### PR TITLE
Add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ docker/resources
 /.vscode
 
 .claude
+.envrc


### PR DESCRIPTION
This way I can use direnv with specific settings, without accidentally commitng them to this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->