### PR TITLE
Use make native file caching

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,12 @@ To contribute you will need Rust, cargo, cross, trunk, wasm-bindgen, and cargo-s
 make install-tools
 ```
 
+To force a reinstall of tooling or updating to the latest version, you can run:
+
+```bash
+make -B install-tools
+```
+
 ### Steps to Contribute
 
 1. **Fork the Repository**: Start by forking the Tuliprox repository to your GitHub account.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
-# --- Setup and OS Detection ---
-OS   := $(shell uname -s)
+# OS Detection
+OS := $(shell uname -s)
 ARCH := $(shell uname -m)
 
+# Paths
+CARGO_BIN_DIR := $(HOME)/.cargo/bin
+
 # Tool Commands
-CARGO            := cargo
-RUSTUP           := rustup
+RUSTUP := $(CARGO_BIN_DIR)/rustup
+CARGO := $(CARGO_BIN_DIR)/cargo
+CROSS := $(CARGO_BIN_DIR)/cross
+TRUNK := $(CARGO_BIN_DIR)/trunk
+WASM_BINDGEN := $(CARGO_BIN_DIR)/wasm-bindgen
+CARGO_SET_VERSION := $(CARGO_BIN_DIR)/cargo-set-version
+
 # Explicitly force stable/nightly to avoid system-wide overrides
 CARGO_STABLE     := $(CARGO) +stable
 CARGO_NIGHTLY    := $(CARGO) +nightly
@@ -25,23 +33,53 @@ help: ## Display this help
 ##@ Prerequisites:
 
 .PHONY: install-tools
-install-tools: check-rustup install-nightly-fmt ## Install all required development tools
-	@echo "📦 Checking and installing CLI tools..."
-	@command -v cross >/dev/null || $(CARGO_STABLE) install cross
-	@command -v trunk >/dev/null || $(CARGO_STABLE) install trunk
-	@command -v wasm-bindgen >/dev/null || $(CARGO_STABLE) install wasm-bindgen-cli
-	@command -v cargo-set-version >/dev/null || $(CARGO_STABLE) install cargo-edit
-	@echo "✅ All tools installed"
-
-.PHONY: check-rustup
-check-rustup: ## Ensure rustup is installed
-	@command -v $(RUSTUP) >/dev/null || (echo "❌ rustup not found. Please install it from https://rustup.rs"; exit 1)
+install-tools: rustup install-nightly-fmt cross trunk wasm-bindgen cargo-set-version ## Install required development tools
 
 .PHONY: install-nightly-fmt
 install-nightly-fmt: ## Install nightly toolchain specifically for formatting
 	@echo "📦 Ensuring nightly rustfmt is available"
 	@$(RUSTUP) toolchain install nightly --component rustfmt --profile minimal
 	@echo "✅ Nightly rustfmt ready"
+
+.PHONY: rustup
+rustup: $(RUSTUP) ## Install Rust toolchain and cargo
+
+$(RUSTUP):
+	@echo "📦 Installing cargo"
+	@curl -sL https://sh.rustup.rs | sh -s -- -y
+	@echo "✅ Cargo installed"
+
+.PHONY: cross
+cross: $(CROSS) ## Install cross (multi-platform build tool)
+
+$(CROSS):
+	@echo "📦 Installing cross"
+	@$(CARGO) install cross
+	@echo "✅ Cross installed"
+
+.PHONY: trunk
+trunk: $(TRUNK) ## Install trunk (frontend build tool)
+
+$(TRUNK):
+	@echo "📦 Installing trunk"
+	@$(CARGO) install trunk
+	@echo "✅ Trunk installed"
+
+.PHONY: wasm-bindgen
+wasm-bindgen: $(WASM_BINDGEN) ## Install wasm-bindgen CLI (for frontend builds)
+
+$(WASM_BINDGEN):
+	@echo "📦 Installing wasm-bindgen CLI"
+	@$(CARGO) install wasm-bindgen-cli
+	@echo "✅ wasm-bindgen CLI installed"
+
+.PHONY: cargo-set-version
+cargo-set-version: $(CARGO_SET_VERSION) ## Install cargo-set-version (for version management)
+
+$(CARGO_SET_VERSION):
+	@echo "📦 Installing $@"
+	@$(CARGO) install cargo-edit
+	@echo "✅ $@ installed"
 
 ##@ Development:
 


### PR DESCRIPTION
To force redo cached tasks (reinstall tools), a user can run `make -B
install-tools`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized binary path management for development tools to make tool resolution more predictable.
  * Reworked installation flow into explicit, per-tool installation steps for clearer setup status and reliability.
  * Updated install workflow to require each tool explicitly, improving repeatable and maintainable environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->