### PR TITLE
Fix config format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - **Favorites Redesign**: Replaced implicit `create_alias` with explicit `add_favourite(group_name)` script function.
   - **EpgSmartMatch**: Field `name_prefix` syntax needs to be changed from  `name_prefix: !suffix "."` to `name_prefix: { suffix: "." }`.
   - **Sort**: Sort can now use filter to sort specific entries.
-  
+
     ```yaml
       sort:
         match_as_ascii: true
@@ -37,12 +37,12 @@
               - "!CHAN_SEQ!"
               - '(?i)\bHD\b'
               - '(?i)\bSD\b'
-        ```
-    
+      ```
+
   - Trakt api config field `key` is now `api_key`. Added `user_agent` field to Trakt api config
   - resolve_vod_delay and resolve_series_delay are now merged as resolve_delay, added `probe_live` and `probe_live_interval_hours` for live stream
     probing.
-  
+
       ```yaml
 
        # Before (deprecated)
@@ -53,7 +53,7 @@
          resolve_series: true
          resolve_series_delay: 2
       ```
-    
+
       ```yaml
 
        # After (new consolidated)

--- a/README.md
+++ b/README.md
@@ -2328,6 +2328,7 @@ be migrated to the corresponding file (`false` → `api_proxy.yml`, `true` → `
 If you set  `use_user_db` to `true` you need to use the `Web-UI` to `edit`/`add`/`remove` users.
 
 To access the api for:
+
 - `xtream` use url like `http://192.169.1.2/player_api.php?username={}&password={}`
 - `m3u` use url `http://192.169.1.2/get.php?username={}&password={}`
   or with token
@@ -2727,11 +2728,11 @@ todo.
 You have a provider who supports the xtream api.
 
 The provider gives you:
+
 - the url: `http://fantastic.provider.xyz:8080`
 - username: `tvjunkie`
 - password: `junkie.secret`
 - epg_url: `http://fantastic.provider.xyz:8080/xmltv.php?username=tvjunkie&password=junkie.secret`
-
 
 To use `tuliprox` you need to create the configuration.
 The configuration consist of 4 files.
@@ -2833,6 +2834,7 @@ If no server is specified for a user, the default one is taken.
 
 To access a xtream api from our IPTV-application we need at least 3 information  the `url`, `username` and `password`.
 All this information are now defined in `api-proxy.yml`.
+
 - url: `http://192.168.1.41:8901`
 - username: `xt`
 - password: `xt.secret`

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 # TULIPROX_HOME should point to /app for docker
-threads: 0
+process_parallel: true
 api:
   host: 0.0.0.0
   port: 8901
@@ -75,6 +75,7 @@ reverse_proxy:
     backoff_multiplier: 1.0
   stream:
     shared_burst_buffer_mb: 12 # default 12 MB
+  rewrite_secret: ${env:TULIPROX_PROXY_REWRITE_SECRET} # use openssl rand -hex 16
 
 library:
   enabled: true


### PR DESCRIPTION
Fix #586 

Following isn't resolved yet:

```shell
TULIPROX_PROXY_REWRITE_SECRET=$(openssl rand -hex 16) TULIPROX_HOME=~/.tuliprox target/release/tuliprox
[2026-02-15T11:34:19+01:00 INFO tuliprox::utils::logging] Log timezone system localtime (TZ)
[2026-02-15T11:34:19+01:00 INFO tuliprox::utils::logging] Log Level debug
[2026-02-15T11:34:19+01:00 INFO tuliprox] Version: 3.2.87
[2026-02-15T11:34:19+01:00 INFO tuliprox] Build time: 2026-02-15 10:07:57 UTC
[2026-02-15T11:34:19+01:00 ERROR tuliprox] Tuliprox error: Failed to canonicalize directory path: No such file or directory (os error 2)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Enabled parallel processing via a simplified boolean configuration to improve throughput.
  * Switched reverse-proxy rewrite credential to an environment-sourced secret for safer, non-hardcoded deployment of proxy stream operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->