### PR TITLE
fixed: probe_live was ignored.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - **Favorites Redesign**: Replaced implicit `create_alias` with explicit `add_favourite(group_name)` script function.
   - **EpgSmartMatch**: Field `name_prefix` syntax needs to be changed from  `name_prefix: !suffix "."` to `name_prefix: { suffix: "." }`.
   - **Sort**: Sort can now use filter to sort specific entries.
-  
+
     ```yaml
       sort:
         match_as_ascii: true
@@ -37,12 +37,12 @@
               - "!CHAN_SEQ!"
               - '(?i)\bHD\b'
               - '(?i)\bSD\b'
-        ```
-    
+      ```
+
   - Trakt api config field `key` is now `api_key`. Added `user_agent` field to Trakt api config
   - resolve_vod_delay and resolve_series_delay are now merged as resolve_delay, added `probe_live` and `probe_live_interval_hours` for live stream
     probing.
-  
+
       ```yaml
 
        # Before (deprecated)
@@ -53,7 +53,7 @@
          resolve_series: true
          resolve_series_delay: 2
       ```
-    
+
       ```yaml
 
        # After (new consolidated)

--- a/README.md
+++ b/README.md
@@ -2328,6 +2328,7 @@ be migrated to the corresponding file (`false` → `api_proxy.yml`, `true` → `
 If you set  `use_user_db` to `true` you need to use the `Web-UI` to `edit`/`add`/`remove` users.
 
 To access the api for:
+
 - `xtream` use url like `http://192.169.1.2/player_api.php?username={}&password={}`
 - `m3u` use url `http://192.169.1.2/get.php?username={}&password={}`
   or with token
@@ -2727,11 +2728,11 @@ todo.
 You have a provider who supports the xtream api.
 
 The provider gives you:
+
 - the url: `http://fantastic.provider.xyz:8080`
 - username: `tvjunkie`
 - password: `junkie.secret`
 - epg_url: `http://fantastic.provider.xyz:8080/xmltv.php?username=tvjunkie&password=junkie.secret`
-
 
 To use `tuliprox` you need to create the configuration.
 The configuration consist of 4 files.
@@ -2833,6 +2834,7 @@ If no server is specified for a user, the default one is taken.
 
 To access a xtream api from our IPTV-application we need at least 3 information  the `url`, `username` and `password`.
 All this information are now defined in `api-proxy.yml`.
+
 - url: `http://192.168.1.41:8901`
 - username: `xt`
 - password: `xt.secret`

--- a/backend/src/processing/processor/playlist.rs
+++ b/backend/src/processing/processor/playlist.rs
@@ -18,7 +18,7 @@ use crate::messaging::send_message;
 
 use crate::model::FetchedPlaylist;
 use crate::model::Mapping;
-use crate::model::{ConfigInputFlags, ConfigInputOptions, ConfigTarget, ProcessTargets, TargetOutput};
+use crate::model::{ConfigInputFlags, ConfigInputOptions, ConfigTarget, ProcessTargets};
 use crate::processing::input_cache;
 use crate::processing::input_cache::ClusterState;
 use crate::processing::parser::xmltv::flatten_tvguide;
@@ -919,41 +919,6 @@ async fn playlist_resolve(
     playlist_probe(ctx, target, processed_fpl).await;
 }
 
-fn has_target_m3u_output(target: &ConfigTarget) -> bool {
-    for output in &target.output {
-        if matches!(output, TargetOutput::M3u(_)) {
-            return true;
-        }
-    }
-    false
-}
-
-fn get_xtream_cluster_probe_flag(
-    target: &ConfigTarget,
-    input_options: Option<&ConfigInputOptions>,
-    cluster: XtreamCluster,
-) -> Option<bool> {
-    target.get_xtream_output().map(|_| match cluster {
-        XtreamCluster::Live => input_options.is_some_and(|options| options.has_flag(ConfigInputFlags::ProbeLive)),
-        XtreamCluster::Video => input_options.is_some_and(|options| options.has_flag(ConfigInputFlags::ProbeVod)),
-        XtreamCluster::Series => input_options.is_some_and(|options| options.has_flag(ConfigInputFlags::ProbeSeries)),
-    })
-}
-
-fn is_cluster_probe_enabled_for_target(
-    target: &ConfigTarget,
-    input_options: Option<&ConfigInputOptions>,
-    cluster: XtreamCluster,
-) -> bool {
-    // Probe flags are only authoritative when the target is exactly one xtream output.
-    // For mixed outputs (xtream + m3u), probing remains enabled because non-xtream outputs have no probe flags.
-    if has_target_m3u_output(target) {
-        return true;
-    }
-
-    get_xtream_cluster_probe_flag(target, input_options, cluster).unwrap_or(true)
-}
-
 fn is_probe_supported_item_type(item_type: PlaylistItemType) -> bool {
     matches!(
         item_type,
@@ -1027,7 +992,11 @@ async fn playlist_probe(ctx: &PlaylistProcessingContext, target: &ConfigTarget, 
     let Some(opts) = fpl.input.options.as_ref() else {
         return;
     };
-    if !opts.has_any_flags(ConfigInputFlags::ProbeLive | ConfigInputFlags::ProbeVod | ConfigInputFlags::ProbeSeries) {
+    let probe_live_enabled = opts.has_flag(ConfigInputFlags::ProbeLive);
+    let probe_vod_enabled = opts.has_flag(ConfigInputFlags::ProbeVod);
+    let probe_series_enabled = opts.has_flag(ConfigInputFlags::ProbeSeries);
+
+    if !(probe_live_enabled || probe_vod_enabled || probe_series_enabled) {
         return;
     }
     if !ctx.config.is_ffprobe_enabled().await {
@@ -1036,12 +1005,15 @@ async fn playlist_probe(ctx: &PlaylistProcessingContext, target: &ConfigTarget, 
 
     let input_name = fpl.input.name.clone();
     let input_type = fpl.input.input_type;
-    let live_probe_settings =
+    let live_probe_settings = if probe_live_enabled {
         get_live_probe_interval_settings(target, input_type, Some(opts)).map(|(delay, interval_secs)| {
             let interval_signed = i64::try_from(interval_secs).unwrap_or(i64::MAX);
             let cutoff_ts = chrono::Utc::now().timestamp().saturating_sub(interval_signed);
             (delay, interval_secs, cutoff_ts)
-        });
+        })
+    } else {
+        None
+    };
 
     let mut queued_probe_keys: HashSet<(Arc<str>, String)> = HashSet::new();
     let mut queued_live_keys: HashSet<ProviderIdType> = HashSet::new();
@@ -1049,32 +1021,47 @@ async fn playlist_probe(ctx: &PlaylistProcessingContext, target: &ConfigTarget, 
     let mut queued_stream_count = 0usize;
 
     for item in fpl.items() {
-        if !is_cluster_probe_enabled_for_target(target, Some(opts), item.header.xtream_cluster) {
-            continue;
-        }
-
         if !is_probe_supported_item_type(item.header.item_type) {
             continue;
         }
 
-        if item.header.item_type.is_live() {
-            if let Some((resolve_delay, interval_secs, cutoff_ts)) = live_probe_settings {
-                if needs_live_probe(&item, cutoff_ts) {
-                    if let Some(provider_id) = provider_id_from_item(&item) {
-                        if queued_live_keys.insert(provider_id.clone()) {
-                            let task = UpdateTask::ProbeLive {
-                                id: provider_id,
-                                reason: ResolveReasonSet::from_variants(&[ResolveReason::Probe]),
-                                delay: resolve_delay,
-                                interval: interval_secs,
-                            };
-                            mgr.queue_task_background(input_name.clone(), task);
-                            queued_live_count += 1;
+        match item.header.item_type {
+            PlaylistItemType::Live => {
+                if !probe_live_enabled {
+                    continue;
+                }
+
+                if let Some((resolve_delay, interval_secs, cutoff_ts)) = live_probe_settings {
+                    if needs_live_probe(&item, cutoff_ts) {
+                        if let Some(provider_id) = provider_id_from_item(&item) {
+                            if queued_live_keys.insert(provider_id.clone()) {
+                                let task = UpdateTask::ProbeLive {
+                                    id: provider_id,
+                                    reason: ResolveReasonSet::from_variants(&[ResolveReason::Probe]),
+                                    delay: resolve_delay,
+                                    interval: interval_secs,
+                                };
+                                mgr.queue_task_background(input_name.clone(), task);
+                                queued_live_count += 1;
+                            }
                         }
                     }
+                    continue;
                 }
-                continue;
+                // If live probes are enabled but no live-specific settings are available, fall through to the
+                // generic probe path to keep behaviour consistent with non-xtream outputs.
             }
+            PlaylistItemType::Video | PlaylistItemType::LocalVideo => {
+                if !probe_vod_enabled {
+                    continue;
+                }
+            }
+            PlaylistItemType::Series | PlaylistItemType::LocalSeries => {
+                if !probe_series_enabled {
+                    continue;
+                }
+            }
+            _ => continue,
         }
 
         if has_probe_details(&item) {

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,5 @@
 # TULIPROX_HOME should point to /app for docker
-threads: 0
+process_parallel: true
 api:
   host: 0.0.0.0
   port: 8901
@@ -75,6 +75,7 @@ reverse_proxy:
     backoff_multiplier: 1.0
   stream:
     shared_burst_buffer_mb: 12 # default 12 MB
+  rewrite_secret: ${env:TULIPROX_PROXY_REWRITE_SECRET} # use openssl rand -hex 16
 
 library:
   enabled: true


### PR DESCRIPTION
Fixed: probe_live flag was ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API access documentation with token-based URL examples and xmltv-config usage guidance.

* **Configuration**
  * Updated configuration structure: replaced "threads" with "process_parallel" option.
  * Added new reverse proxy secret configuration parameter.

* **Chores**
  * Formatting adjustments to changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->