### PR TITLE
Added new connectoin admission rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,14 +90,60 @@
   - Current-day QoS rebuilds are skipped when the history day is unchanged.
   - Snapshot traversal APIs were reduced to a single repository traversal style to avoid duplicated code paths.
 
+- **Connection Admission Rules**: Added configurable admission strategies to `reverse_proxy.stream.admission_strategies`
+  that control how Tuliprox handles new stream requests when the user or provider connection limit is reached.
+  - `evict_user_same_ip_oldest` — evicts the oldest active connection from the same user and IP to make room.
+  - `evict_user_same_ip_latest` — evicts the newest active connection from the same user and IP to make room.
+  - `evict_user_oldest` — evicts the oldest active connection for the same user, regardless of IP.
+  - `evict_user_latest` — evicts the newest active connection for the same user, regardless of IP.
+  - `grace_instant_stream` — grants a grace period and immediately starts streaming.
+  - `grace_hold_stream` — grants a grace period but holds stream output until the grace check completes.
+  - Strategies are evaluated in order; the first matching strategy wins and blocks later ones.
+  - `grace_instant_stream` and `grace_hold_stream` are mutually exclusive.
+  - Grace strategies require `grace_period_millis > 0`.
+  - Added comprehensive connection handling documentation covering failures, user-visible behavior, priorities, sessions, and reconnects.
+- **Provider URL Selection Strategy**: Added `provider_url_selection_policy` to provider definitions in `source.yml`.
+  - `resume_last_working` (default) — after failover, the provider continues using the last known working URL until it fails again.
+  - `restart_from_first` — after failover, the provider always tries from the first URL on the next request.
+- **Structured Error Types**: Replaced the old `TuliproxErrorKind`-based error model with a typed `TuliproxError` enum
+  using `thiserror`. Each config domain now has its own variant (e.g., `ConfigStream`, `ConfigInput`, `ConfigSource`,
+  `ConfigApiProxy`, `ProxyUser`), making error messages precise and traceable.
+- **Web UI Landing Page**: Added `landing_page` setting to `web_ui` config to choose the initial view after login.
+  Supported values: `dashboard`, `stats`, `streams`, `stream_history`, `downloads`, `users`, `config`,
+  `source_editor`, `playlist_update`, `playlist_settings`, `playlist_explorer`, `playlist_epg`, `rbac`.
+- **Runtime Config Report**: Added opt-in startup dump of the complete effective runtime configuration.
+  - `log.runtime_config_report_enabled` (default `false`) — enables the report.
+  - `log.runtime_config_report_format` — `yaml` (default) or `json`.
+  - Sensitive values (passwords, secrets, tokens, API keys) are automatically redacted.
+  - Includes prepared `config.yml`, `source.yml`, loaded mappings/templates/api-proxy sections, and resolved paths.
+- **CVD-Friendly Theme**: Web UI now includes a CVD (color vision deficiency) friendly theme option.
+
 ## 🐛 Fixes
 
 - **Shutdown Diagnostics**: Stream-history shutdown now reports dead worker situations instead of silently swallowing them.
 - **Release Workflow Safety**:
   - `master` releases now refuse to build non-release versions when the patch component is not `0`.
   - The release-version validation now runs before expensive build steps for an early exit.
+- **provider:// Scheme**: Fixed `provider://` URL scheme resolution for failover scenarios.
+- **Log Level Change**: Fixed runtime log level changes not taking effect.
+- **API User Category Selection**: Fixed API user category selection in the Web UI.
+- **Refactored Playlist And EPG Explorer**: Playlist Explorer and EPG Explorer have been refactored for improved reliability and UX.
+- HLS session info now reports accurate duration and total transferred data.
 
 ## ⚙️ New Settings
+
+- **config.yml (`reverse_proxy.stream`)**:
+  - Added `admission_strategies` (optional list): ordered list of admission strategy rules.
+    Available strategies: `evict_user_same_ip_oldest`, `evict_user_same_ip_latest`, `evict_user_oldest`, `evict_user_latest`,  
+    `grace_instant_stream`, `grace_hold_stream`.
+- **config.yml (`web_ui`)**:
+  - Added `landing_page` (optional, default `dashboard`): initial view after login.
+- **config.yml (`log`)**:
+  - Added `runtime_config_report_enabled` (bool, default `false`): enables full runtime config dump at startup.
+  - Added `runtime_config_report_format` (`yaml` | `json`, default `yaml`): output format for the runtime config report.
+- **source.yml (`providers`)**:
+  - Added `provider_url_selection_policy` (`resume_last_working` | `restart_from_first`, default `resume_last_working`):
+    controls URL selection behavior after provider failover.
 
 - **config.yml (`reverse_proxy`)**:
   - Added `qos_aggregation` (optional) with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,12 @@
   - This prevents parallel TS/VOD sockets from being collapsed into one logical playback.
   - Soft connections still work normally: once `max_connections` is full, an additional socket may still be admitted as `Soft` when
     `soft_connections > 0`, and provider-side priority/preemption rules still apply afterward.
+  - Admission-driven evictions now record the just-evicted session briefly so aggressive player reconnect loops cannot immediately evict the new
+    winner back out again.
+  - This is not a full user cooldown: reconnects still succeed when a hard slot or soft slot is actually free, and switching to another channel is
+    unaffected.
+  - For socket-bound TS/VOD/local playback, the anti-ping-pong protection uses a short same-user, same-IP, same-channel winner guard because those
+    clients do not provide a stable reconnect session identifier.
   - HLS activity refresh and cleanup dispatch were moved off the request/drop fast path so activity updates do not block segment responses and
     cleanup events are not silently lost when queues are temporarily full.
 - **Provider URL Selection Strategy**: Added `provider_url_selection_policy` to provider definitions in `source.yml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,9 +99,19 @@
   - `grace_instant_stream` — grants a grace period and immediately starts streaming.
   - `grace_hold_stream` — grants a grace period but holds stream output until the grace check completes.
   - Strategies are evaluated in order; the first matching strategy wins and blocks later ones.
+  - Configuration rejects obviously shadowed orderings where `evict_user_oldest` is placed before `evict_user_same_ip_oldest`,
+    or `evict_user_latest` before `evict_user_same_ip_latest`.
   - `grace_instant_stream` and `grace_hold_stream` are mutually exclusive.
   - Grace strategies require `grace_period_millis > 0`.
   - Added comprehensive connection handling documentation covering failures, user-visible behavior, priorities, sessions, and reconnects.
+- **Session Handling Boundary**: HLS and catchup remain session-based for continuity and provider affinity, but regular TS/VOD/local playback is now
+  enforced as socket-bound admission.
+  - A second non-HLS socket now counts as a second user connection even for the same user, IP, and stream.
+  - This prevents parallel TS/VOD sockets from being collapsed into one logical playback.
+  - Soft connections still work normally: once `max_connections` is full, an additional socket may still be admitted as `Soft` when
+    `soft_connections > 0`, and provider-side priority/preemption rules still apply afterward.
+  - HLS activity refresh and cleanup dispatch were moved off the request/drop fast path so activity updates do not block segment responses and
+    cleanup events are not silently lost when queues are temporarily full.
 - **Provider URL Selection Strategy**: Added `provider_url_selection_policy` to provider definitions in `source.yml`.
   - `resume_last_working` (default) — after failover, the provider continues using the last known working URL until it fails again.
   - `restart_from_first` — after failover, the provider always tries from the first URL on the next request.

--- a/Makefile
+++ b/Makefile
@@ -130,11 +130,11 @@ fmt-check: ## Check if code follows formatting rules (Nightly)
 .PHONY: markdown-lint
 markdown-lint: ## Lint markdown files
 	@echo "==> Linting markdown files"
-	@command -v markdownlint-cli2 >/dev/null 2>&1 || { \
-		echo "❌ markdownlint-cli2 not found. Install with: npm install -g markdownlint-cli2"; \
-		exit 1; \
-	}
-	@markdownlint-cli2 "**/*.md"
+# 	@command -v markdownlint-cli2 >/dev/null 2>&1 || { \
+# 		echo "❌ markdownlint-cli2 not found. Install with: npm install -g markdownlint-cli2"; \
+# 		exit 1; \
+# 	}
+	@npx markdownlint-cli2 "docs/src/**/*.md" "README.md" "CHANGELOG.md" "CONTRIBUTING.md"
 	@echo "✅ Markdown linting complete"
 
 .PHONY: docs

--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -479,14 +479,31 @@ pub(in crate::api) async fn resolve_admission_with_strategies(
     _fingerprint: &Fingerprint,
     is_session_request: bool,
     session_token: Option<&str>,
+    activate_unbound_session: bool,
 ) -> (crate::api::model::ConnectionAdmission, Option<crate::api::model::GraceMode>) {
     use crate::api::model::{AdmissionDecision, ConnectionAdmission, ConnectionKind, StrategyContext, evaluate_strategy};
     use shared::model::UserConnectionPermission;
 
     let admission = if is_session_request {
-        app_state.get_connection_admission_for_session(
-            username, max_connections, soft_connections, session_token.unwrap_or_default(),
-        ).await
+        if activate_unbound_session {
+            app_state
+                .get_connection_admission_for_session_activation(
+                    username,
+                    max_connections,
+                    soft_connections,
+                    session_token.unwrap_or_default(),
+                )
+                .await
+        } else {
+            app_state
+                .get_connection_admission_for_session(
+                    username,
+                    max_connections,
+                    soft_connections,
+                    session_token.unwrap_or_default(),
+                )
+                .await
+        }
     } else {
         app_state.get_connection_admission(username, max_connections, soft_connections).await
     };
@@ -522,14 +539,25 @@ pub(in crate::api) async fn resolve_admission_with_strategies(
                 debug!("Evicting connection {} for user {username}", target.addr);
                 app_state.connection_manager.release_connection_as_kicked(&target.addr).await;
                 let retry_admission = if is_session_request {
-                    app_state
-                        .get_connection_admission_for_session(
-                            username,
-                            max_connections,
-                            soft_connections,
-                            session_token.unwrap_or_default(),
-                        )
-                        .await
+                    if activate_unbound_session {
+                        app_state
+                            .get_connection_admission_for_session_activation(
+                                username,
+                                max_connections,
+                                soft_connections,
+                                session_token.unwrap_or_default(),
+                            )
+                            .await
+                    } else {
+                        app_state
+                            .get_connection_admission_for_session(
+                                username,
+                                max_connections,
+                                soft_connections,
+                                session_token.unwrap_or_default(),
+                            )
+                            .await
+                    }
                 } else {
                     app_state
                         .get_connection_admission(username, max_connections, soft_connections)
@@ -550,6 +578,73 @@ pub(in crate::api) async fn resolve_admission_with_strategies(
 
     debug!("No admission strategy could admit user {username}");
     (admission, None)
+}
+
+struct SessionActivationRequest<'a> {
+    fingerprint: &'a Fingerprint,
+    input: &'a ConfigInput,
+    user: &'a ProxyUserCredentials,
+    session_token: &'a str,
+    virtual_id: VirtualId,
+    stream_url: &'a str,
+    connection_permission: UserConnectionPermission,
+    connection_kind: crate::api::model::ConnectionKind,
+}
+
+async fn activate_session_before_stream_open(
+    app_state: &Arc<AppState>,
+    request: SessionActivationRequest<'_>,
+) -> (crate::api::model::ConnectionAdmission, bool) {
+    let SessionActivationRequest {
+        fingerprint,
+        input,
+        user,
+        session_token,
+        virtual_id,
+        stream_url,
+        connection_permission,
+        connection_kind,
+    } = request;
+    let limits_enabled =
+        app_state.app_config.config.load().user_access_control && (user.max_connections > 0 || user.soft_connections > 0);
+    if !limits_enabled || connection_permission == UserConnectionPermission::GracePeriod {
+        return (
+            crate::api::model::ConnectionAdmission {
+                permission: connection_permission,
+                kind: Some(connection_kind),
+            },
+            false,
+        );
+    }
+
+    let created_placeholder = app_state
+        .active_users
+        .ensure_user_session_placeholder(crate::api::model::CreateUserSessionParams {
+            user,
+            session_token,
+            virtual_id,
+            provider: input.name.as_ref(),
+            stream_url,
+            addr: &fingerprint.addr,
+            connection_permission,
+            connection_kind: Some(connection_kind),
+        })
+        .await;
+
+    let (admission, _grace_mode) = resolve_admission_with_strategies(
+        app_state,
+        &user.username,
+        user.max_connections,
+        user.soft_connections,
+        &fingerprint.client_ip,
+        fingerprint,
+        true,
+        Some(session_token),
+        true,
+    )
+    .await;
+
+    (admission, created_placeholder)
 }
 
 pub fn get_stream_alternative_url(stream_url: &str, input: &ConfigInput, alias_input: &Arc<ProviderConfig>) -> String {
@@ -1120,6 +1215,10 @@ pub async fn force_provider_stream_response(
     {
         Ok(stream_details) => stream_details,
         Err(err) => {
+            app_state
+                .active_users
+                .release_unbound_session_reservation(&ctx.user.username, &user_session.token, false)
+                .await;
             error!("Failed to stream: {err}");
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
@@ -1185,6 +1284,10 @@ pub async fn force_provider_stream_response(
     }
 
     app_state.connection_manager.release_provider_handle(stream_details.provider_handle).await;
+    app_state
+        .active_users
+        .release_unbound_session_reservation(&ctx.user.username, &user_session.token, false)
+        .await;
     if let (Some(stream), _stream_info) =
         create_channel_unavailable_stream(&app_state.app_config, &[], StatusCode::SERVICE_UNAVAILABLE)
     {
@@ -1227,6 +1330,25 @@ pub async fn stream_response(
 
     let virtual_id = stream_channel.virtual_id;
     let item_type = stream_channel.item_type;
+    let mut connection_permission = connection_permission;
+    let mut connection_kind = connection_kind;
+    let (final_admission, created_placeholder_session) = activate_session_before_stream_open(
+        app_state,
+        SessionActivationRequest {
+            fingerprint,
+            input,
+            user,
+            session_token,
+            virtual_id,
+            stream_url,
+            connection_permission,
+            connection_kind,
+        },
+    )
+    .await;
+    connection_permission = final_admission.permission;
+    connection_kind = final_admission.kind.unwrap_or(connection_kind);
+
     let allow_shared_reuse = connection_permission != UserConnectionPermission::Exhausted || allow_exhausted_shared_reconnect;
 
     let share_stream = is_stream_share_enabled(item_type, target);
@@ -1279,6 +1401,10 @@ pub async fn stream_response(
     };
 
     if connection_permission == UserConnectionPermission::Exhausted {
+        app_state
+            .active_users
+            .release_unbound_session_reservation(&user.username, session_token, created_placeholder_session)
+            .await;
         record_connect_failed_attempt(ConnectFailedAttempt {
             app_state,
             fingerprint,
@@ -1322,6 +1448,10 @@ pub async fn stream_response(
     {
         Ok(stream_details) => stream_details,
         Err(err) => {
+            app_state
+                .active_users
+                .release_unbound_session_reservation(&user.username, session_token, created_placeholder_session)
+                .await;
             error!("Failed to stream: {err}");
             return StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
@@ -1520,6 +1650,10 @@ pub async fn stream_response(
         return stream_resp.into_response();
     }
     app_state.connection_manager.release_provider_handle(stream_details.provider_handle).await;
+    app_state
+        .active_users
+        .release_unbound_session_reservation(&user.username, session_token, created_placeholder_session)
+        .await;
     StatusCode::BAD_REQUEST.into_response()
 }
 
@@ -1710,6 +1844,7 @@ pub async fn local_stream_response(
         trace!("Try to open stream {}", sanitize_sensitive_info(&pli.url));
     }
 
+    let mut connection_permission = connection_permission;
     if connection_permission == UserConnectionPermission::Exhausted {
         let allow_session_reopen = if let Some(session_token) = playback_session_token {
             user.max_connections > 0
@@ -1744,6 +1879,7 @@ pub async fn local_stream_response(
             )
             .into_response();
         }
+        connection_permission = UserConnectionPermission::Allowed;
     }
 
     let path = PathBuf::from(pli.url.strip_prefix("file://").unwrap_or(&pli.url));
@@ -1829,6 +1965,38 @@ pub async fn local_stream_response(
     } else {
         stream
     };
+    let mut connection_kind = connection_kind;
+    if let Some(session_token) = playback_session_token {
+        let (final_admission, created_placeholder) = activate_session_before_stream_open(
+            app_state,
+            SessionActivationRequest {
+                fingerprint,
+                input,
+                user,
+                session_token,
+                virtual_id: pli.virtual_id,
+                stream_url: &pli.url,
+                connection_permission,
+                connection_kind,
+            },
+        )
+        .await;
+        connection_permission = final_admission.permission;
+        connection_kind = final_admission.kind.unwrap_or(connection_kind);
+
+        if connection_permission == UserConnectionPermission::Exhausted {
+            app_state
+                .active_users
+                .release_unbound_session_reservation(&user.username, session_token, created_placeholder)
+                .await;
+            return create_custom_video_stream_response(
+                app_state,
+                &fingerprint.addr,
+                CustomVideoStreamType::UserConnectionsExhausted,
+            )
+            .into_response();
+        }
+    }
     let mut grace_period_options = app_state.get_grace_options();
     if connection_permission != UserConnectionPermission::GracePeriod {
         grace_period_options.period_millis = 0;
@@ -2207,12 +2375,20 @@ where
     stream_json_array_stream(data)
 }
 
-pub fn create_session_fingerprint(fingerprint: &Fingerprint, username: &str, virtual_id: u32) -> String {
-    concat_string!(&fingerprint.key, "|", username, "|", &virtual_id.to_string())
+pub fn create_session_fingerprint(fingerprint: &Fingerprint, username: &str, virtual_id: u32, socket_bound: bool) -> String {
+    if socket_bound {
+        concat_string!(&fingerprint.addr.to_string(), "|", username, "|", &virtual_id.to_string())
+    } else {
+        concat_string!(&fingerprint.key, "|", username, "|", &virtual_id.to_string())
+    }
 }
 
 pub fn create_catchup_session_key(fingerprint: &Fingerprint, username: &str, virtual_id: u32) -> String {
     concat_string!("catchup|", &fingerprint.key, "|", username, "|", &virtual_id.to_string(), "|session")
+}
+
+pub(crate) fn is_session_based_playback(item_type: PlaylistItemType, extension: Option<&str>) -> bool {
+    item_type.is_live_adaptive() || matches!(extension, Some(ext) if ext == HLS_EXT || ext == DASH_EXT)
 }
 
 pub(crate) fn should_allow_exhausted_shared_reconnect(
@@ -2495,6 +2671,7 @@ mod tests {
             addr: "127.0.0.1:1234".parse().unwrap_or_else(|_| unreachable!()),
             ts: 1,
             permission: UserConnectionPermission::Allowed,
+            counted: false,
         };
 
         assert!(should_allow_exhausted_shared_reconnect(
@@ -2877,6 +3054,7 @@ mod tests {
             &create_test_fingerprint("127.0.0.1:55153".parse().unwrap_or_else(|_| unreachable!())),
             true,
             Some("tok-third"),
+            false,
         )
         .await;
 
@@ -2933,6 +3111,90 @@ mod tests {
         let active_streams = app_state.active_users.active_streams().await;
         assert_eq!(active_streams.len(), 1, "local file streaming should register an active stream");
         assert_eq!(active_streams[0].channel.item_type, PlaylistItemType::LocalVideo);
+    }
+
+    #[tokio::test]
+    async fn local_stream_response_rechecks_limits_before_registering_socket_bound_streams() {
+        let mut app_cfg = create_test_app_config();
+        let mut config = Config::default();
+        config.user_access_control = true;
+        app_cfg.config = Arc::new(ArcSwap::from_pointee(config));
+        let app_state = create_test_app_state_for_config(Arc::new(app_cfg));
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let file_path = temp_dir.path().join("local-race-test.mkv");
+        tokio::fs::write(&file_path, Bytes::from_static(b"local-stream")).await.expect("write local file");
+
+        let first_addr = "127.0.0.1:55131".parse().unwrap_or_else(|_| unreachable!());
+        let second_addr = "127.0.0.1:55132".parse().unwrap_or_else(|_| unreachable!());
+        let first_fingerprint = create_test_fingerprint(first_addr);
+        let second_fingerprint = create_test_fingerprint(second_addr);
+        let channel = create_test_local_channel(&format!("file://{}", file_path.display()));
+        let input = ConfigInput { input_type: InputType::Library, ..ConfigInput::default() };
+        let mut user = ProxyUserCredentials::default();
+        user.username = "local-limit-user".to_string();
+        user.max_connections = 1;
+        let target = ConfigTarget {
+            id: 1,
+            enabled: true,
+            name: "test".to_string(),
+            options: None,
+            sort: None,
+            filter: Filter::default(),
+            output: Vec::new(),
+            rename: None,
+            mapping_ids: None,
+            mapping: Arc::new(ArcSwapOption::default()),
+            favourites: None,
+            processing_order: ProcessingOrder::default(),
+            watch: None,
+            use_memory_cache: false,
+        };
+        let first_token = create_session_fingerprint(&first_fingerprint, &user.username, channel.virtual_id, true);
+        let second_token = create_session_fingerprint(&second_fingerprint, &user.username, channel.virtual_id, true);
+
+        let _first_response = local_stream_response(
+            &first_fingerprint,
+            &app_state,
+            channel.clone(),
+            &HeaderMap::default(),
+            &input,
+            &target,
+            &user,
+            UserConnectionPermission::Allowed,
+            crate::api::model::ConnectionKind::Normal,
+            Some(&first_token),
+            false,
+        )
+        .await
+        .into_response();
+
+        let _second_response = local_stream_response(
+            &second_fingerprint,
+            &app_state,
+            channel,
+            &HeaderMap::default(),
+            &input,
+            &target,
+            &user,
+            UserConnectionPermission::Allowed,
+            crate::api::model::ConnectionKind::Normal,
+            Some(&second_token),
+            false,
+        )
+        .await
+        .into_response();
+
+        assert_eq!(app_state.active_users.user_connections(&user.username).await, 1);
+        assert_eq!(app_state.active_users.active_streams().await.len(), 1);
+        assert_eq!(
+            app_state
+                .active_users
+                .connection_admission_for_session(&user.username, user.max_connections, user.soft_connections, &second_token)
+                .await
+                .permission,
+            UserConnectionPermission::Exhausted,
+            "failed second open must not leave a placeholder session that bypasses admission"
+        );
     }
 
     #[tokio::test]
@@ -3295,5 +3557,253 @@ mod tests {
             .connection_admission_for_session(&user.username, user.max_connections, user.soft_connections, playback_session_token)
             .await;
         assert_eq!(session_admission.kind, Some(crate::api::model::ConnectionKind::Soft));
+    }
+
+    #[tokio::test]
+    async fn activated_session_admission_reserves_hls_slots_via_api_utils() {
+        let app_state = create_test_app_state();
+        let mut user = ProxyUserCredentials::default();
+        user.username = "hls-user".to_string();
+        user.max_connections = 1;
+
+        let first_addr: std::net::SocketAddr = "127.0.0.1:55177".parse().unwrap_or_else(|_| unreachable!());
+        let second_addr: std::net::SocketAddr = "127.0.0.1:55178".parse().unwrap_or_else(|_| unreachable!());
+        let first_fingerprint = create_test_fingerprint(first_addr);
+        let second_fingerprint = create_test_fingerprint(second_addr);
+
+        app_state
+            .active_users
+            .create_user_session(crate::api::model::CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-hls-first",
+                virtual_id: 7101,
+                provider: "provider-a",
+                stream_url: "http://provider-1.example/live/7101.m3u8",
+                addr: &first_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(crate::api::model::ConnectionKind::Normal),
+            })
+            .await;
+        app_state
+            .active_users
+            .create_user_session(crate::api::model::CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-hls-second",
+                virtual_id: 7102,
+                provider: "provider-a",
+                stream_url: "http://provider-1.example/live/7102.m3u8",
+                addr: &second_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(crate::api::model::ConnectionKind::Normal),
+            })
+            .await;
+
+        let first_admission = resolve_admission_with_strategies(
+            &app_state,
+            &user.username,
+            user.max_connections,
+            user.soft_connections,
+            &first_fingerprint.client_ip,
+            &first_fingerprint,
+            true,
+            Some("tok-hls-first"),
+            true,
+        )
+        .await
+        .0;
+        let second_admission = resolve_admission_with_strategies(
+            &app_state,
+            &user.username,
+            user.max_connections,
+            user.soft_connections,
+            &second_fingerprint.client_ip,
+            &second_fingerprint,
+            true,
+            Some("tok-hls-second"),
+            true,
+        )
+        .await
+        .0;
+
+        assert_eq!(first_admission.permission, UserConnectionPermission::Allowed);
+        assert_eq!(second_admission.permission, UserConnectionPermission::Exhausted);
+    }
+
+    #[tokio::test]
+    async fn socket_bound_playback_tokens_enforce_hard_limits_per_socket() {
+        let app_state = create_test_app_state();
+        let mut user = ProxyUserCredentials::default();
+        user.username = "user1".to_string();
+        user.max_connections = 1;
+
+        let first_addr: std::net::SocketAddr = "127.0.0.1:55171".parse().unwrap_or_else(|_| unreachable!());
+        let second_addr: std::net::SocketAddr = "127.0.0.1:55172".parse().unwrap_or_else(|_| unreachable!());
+        let first_fingerprint = create_test_fingerprint(first_addr);
+        let first_token = create_session_fingerprint(&first_fingerprint, &user.username, 5001, true);
+        let second_fingerprint = create_test_fingerprint(second_addr);
+        let second_token = create_session_fingerprint(&second_fingerprint, &user.username, 5001, true);
+
+        app_state.connection_manager.add_connection(&first_addr).await;
+        app_state.connection_manager.add_connection(&second_addr).await;
+
+        app_state
+            .active_users
+            .create_user_session(crate::api::model::CreateUserSessionParams {
+                user: &user,
+                session_token: &first_token,
+                virtual_id: 5001,
+                provider: "provider-a",
+                stream_url: "http://provider-1.example/vod/5001.ts",
+                addr: &first_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(crate::api::model::ConnectionKind::Normal),
+            })
+            .await;
+
+        app_state
+            .active_users
+            .update_connection(crate::api::model::ActiveUserConnectionParams {
+                uid: 5001,
+                meter_uid: 0,
+                username: &user.username,
+                max_connections: user.max_connections,
+                soft_connections: user.soft_connections,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &first_fingerprint,
+                provider: "provider-a",
+                stream_channel: &create_test_live_channel("http://provider-1.example/vod/5001.ts"),
+                user_agent: std::borrow::Cow::Borrowed("ua"),
+                session_token: Some(&first_token),
+            })
+            .await;
+
+        let admission = app_state
+            .active_users
+            .connection_admission_for_session(&user.username, user.max_connections, user.soft_connections, &second_token)
+            .await;
+        assert_eq!(admission.permission, UserConnectionPermission::Exhausted);
+    }
+
+    #[tokio::test]
+    async fn socket_bound_playback_tokens_still_allow_soft_slots() {
+        let app_state = create_test_app_state();
+        let mut user = ProxyUserCredentials::default();
+        user.username = "soft-user".to_string();
+        user.max_connections = 1;
+        user.soft_connections = 1;
+        user.priority = 0;
+        user.soft_priority = 9;
+
+        let first_addr: std::net::SocketAddr = "127.0.0.1:55173".parse().unwrap_or_else(|_| unreachable!());
+        let second_addr: std::net::SocketAddr = "127.0.0.1:55174".parse().unwrap_or_else(|_| unreachable!());
+        let third_addr: std::net::SocketAddr = "127.0.0.1:55175".parse().unwrap_or_else(|_| unreachable!());
+        let first_fingerprint = create_test_fingerprint(first_addr);
+        let second_fingerprint = create_test_fingerprint(second_addr);
+        let first_token = create_session_fingerprint(&first_fingerprint, &user.username, 6001, true);
+        let second_token = create_session_fingerprint(&second_fingerprint, &user.username, 6001, true);
+        let third_fingerprint = create_test_fingerprint(third_addr);
+        let third_token = create_session_fingerprint(&third_fingerprint, &user.username, 6001, true);
+
+        app_state.connection_manager.add_connection(&first_addr).await;
+        app_state.connection_manager.add_connection(&second_addr).await;
+
+        app_state
+            .active_users
+            .create_user_session(crate::api::model::CreateUserSessionParams {
+                user: &user,
+                session_token: &first_token,
+                virtual_id: 6001,
+                provider: "provider-a",
+                stream_url: "http://provider-1.example/vod/6001.ts",
+                addr: &first_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(crate::api::model::ConnectionKind::Normal),
+            })
+            .await;
+        app_state
+            .active_users
+            .update_connection(crate::api::model::ActiveUserConnectionParams {
+                uid: 6001,
+                meter_uid: 0,
+                username: &user.username,
+                max_connections: user.max_connections,
+                soft_connections: user.soft_connections,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                priority: user.priority,
+                soft_priority: user.soft_priority,
+                fingerprint: &first_fingerprint,
+                provider: "provider-a",
+                stream_channel: &create_test_live_channel("http://provider-1.example/vod/6001.ts"),
+                user_agent: std::borrow::Cow::Borrowed("ua"),
+                session_token: Some(&first_token),
+            })
+            .await;
+
+        let second_admission = app_state
+            .active_users
+            .connection_admission_for_session(&user.username, user.max_connections, user.soft_connections, &second_token)
+            .await;
+        assert_eq!(second_admission.permission, UserConnectionPermission::Allowed);
+        assert_eq!(second_admission.kind, Some(crate::api::model::ConnectionKind::Soft));
+
+        app_state
+            .active_users
+            .create_user_session(crate::api::model::CreateUserSessionParams {
+                user: &user,
+                session_token: &second_token,
+                virtual_id: 6001,
+                provider: "provider-a",
+                stream_url: "http://provider-1.example/vod/6001.ts",
+                addr: &second_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(crate::api::model::ConnectionKind::Soft),
+            })
+            .await;
+        app_state
+            .active_users
+            .update_connection(crate::api::model::ActiveUserConnectionParams {
+                uid: 6002,
+                meter_uid: 0,
+                username: &user.username,
+                max_connections: user.max_connections,
+                soft_connections: user.soft_connections,
+                connection_kind: crate::api::model::ConnectionKind::Soft,
+                priority: user.priority,
+                soft_priority: user.soft_priority,
+                fingerprint: &second_fingerprint,
+                provider: "provider-a",
+                stream_channel: &create_test_live_channel("http://provider-1.example/vod/6002.ts"),
+                user_agent: std::borrow::Cow::Borrowed("ua"),
+                session_token: Some(&second_token),
+            })
+            .await;
+
+        let third_admission = app_state
+            .active_users
+            .connection_admission_for_session(&user.username, user.max_connections, user.soft_connections, &third_token)
+            .await;
+        assert_eq!(third_admission.permission, UserConnectionPermission::Exhausted);
+    }
+
+    #[test]
+    fn session_based_playback_matches_adaptive_types_and_extensions() {
+        assert!(is_session_based_playback(PlaylistItemType::LiveHls, None));
+        assert!(is_session_based_playback(PlaylistItemType::LiveDash, None));
+        assert!(is_session_based_playback(PlaylistItemType::Live, Some(HLS_EXT)));
+        assert!(is_session_based_playback(PlaylistItemType::Live, Some(DASH_EXT)));
+        assert!(!is_session_based_playback(PlaylistItemType::Video, None));
+    }
+
+    #[test]
+    fn create_session_fingerprint_switches_between_logical_and_socket_bound_keys() {
+        let fingerprint = create_test_fingerprint("127.0.0.1:55176".parse().unwrap_or_else(|_| unreachable!()));
+        let logical = create_session_fingerprint(&fingerprint, "user1", 7001, false);
+        let socket_bound = create_session_fingerprint(&fingerprint, "user1", 7001, true);
+
+        assert_ne!(logical, socket_bound);
+        assert!(logical.contains(&fingerprint.key));
+        assert!(socket_bound.contains(&fingerprint.addr.to_string()));
     }
 }

--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -594,7 +594,7 @@ struct SessionActivationRequest<'a> {
 async fn activate_session_before_stream_open(
     app_state: &Arc<AppState>,
     request: SessionActivationRequest<'_>,
-) -> (crate::api::model::ConnectionAdmission, bool) {
+) -> (crate::api::model::ConnectionAdmission, Option<crate::api::model::GraceMode>, bool) {
     let SessionActivationRequest {
         fingerprint,
         input,
@@ -613,6 +613,7 @@ async fn activate_session_before_stream_open(
                 permission: connection_permission,
                 kind: Some(connection_kind),
             },
+            None,
             false,
         );
     }
@@ -631,7 +632,7 @@ async fn activate_session_before_stream_open(
         })
         .await;
 
-    let (admission, _grace_mode) = resolve_admission_with_strategies(
+    let (admission, grace_mode) = resolve_admission_with_strategies(
         app_state,
         &user.username,
         user.max_connections,
@@ -644,7 +645,7 @@ async fn activate_session_before_stream_open(
     )
     .await;
 
-    (admission, created_placeholder)
+    (admission, grace_mode, created_placeholder)
 }
 
 pub fn get_stream_alternative_url(stream_url: &str, input: &ConfigInput, alias_input: &Arc<ProviderConfig>) -> String {
@@ -1332,7 +1333,7 @@ pub async fn stream_response(
     let item_type = stream_channel.item_type;
     let mut connection_permission = connection_permission;
     let mut connection_kind = connection_kind;
-    let (final_admission, created_placeholder_session) = activate_session_before_stream_open(
+    let (final_admission, resolved_grace_mode, created_placeholder_session) = activate_session_before_stream_open(
         app_state,
         SessionActivationRequest {
             fingerprint,
@@ -1346,6 +1347,7 @@ pub async fn stream_response(
         },
     )
     .await;
+    let grace_mode = resolved_grace_mode.or(grace_mode);
     connection_permission = final_admission.permission;
     connection_kind = final_admission.kind.unwrap_or(connection_kind);
 
@@ -1845,6 +1847,7 @@ pub async fn local_stream_response(
     }
 
     let mut connection_permission = connection_permission;
+    let mut grace_mode = None;
     if connection_permission == UserConnectionPermission::Exhausted {
         let allow_session_reopen = if let Some(session_token) = playback_session_token {
             user.max_connections > 0
@@ -1967,7 +1970,7 @@ pub async fn local_stream_response(
     };
     let mut connection_kind = connection_kind;
     if let Some(session_token) = playback_session_token {
-        let (final_admission, created_placeholder) = activate_session_before_stream_open(
+        let (final_admission, resolved_grace_mode, created_placeholder) = activate_session_before_stream_open(
             app_state,
             SessionActivationRequest {
                 fingerprint,
@@ -1981,6 +1984,7 @@ pub async fn local_stream_response(
             },
         )
         .await;
+        grace_mode = resolved_grace_mode;
         connection_permission = final_admission.permission;
         connection_kind = final_admission.kind.unwrap_or(connection_kind);
 
@@ -2000,6 +2004,9 @@ pub async fn local_stream_response(
     let mut grace_period_options = app_state.get_grace_options();
     if connection_permission != UserConnectionPermission::GracePeriod {
         grace_period_options.period_millis = 0;
+    }
+    if let Some(resolved_mode) = grace_mode {
+        grace_period_options.hold_stream = matches!(resolved_mode, crate::api::model::GraceMode::Hold);
     }
     let resolved_connection_kind = if let Some(session_token) = playback_session_token {
         app_state

--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -270,6 +270,7 @@ macro_rules! try_result_not_found {
 use crate::api::panel_api::{can_provision_on_exhausted, create_panel_api_provisioning_stream_details};
 pub use internal_server_error;
 use shared::error::TuliproxError;
+use shared::model::AdmissionStrategy;
 use shared::utils::{default_catchup_session_ttl_secs, default_hls_session_ttl_secs};
 pub use try_option_bad_request;
 pub use try_option_forbidden;
@@ -452,8 +453,7 @@ pub(in crate::api) fn get_stream_options(app_state: &Arc<AppState>) -> StreamOpt
     StreamOptions { stream_retry, buffer_enabled, buffer_size, pipe_provider_stream }
 }
 
-pub(in crate::api) fn get_effective_admission_strategies(app_state: &Arc<AppState>) -> Vec<crate::model::AdmissionStrategy> {
-    use crate::model::AdmissionStrategy;
+pub(in crate::api) fn get_effective_admission_strategies(app_state: &Arc<AppState>) -> Vec<AdmissionStrategy> {
     let config = app_state.app_config.config.load();
     let stream_config = config.reverse_proxy.as_ref().and_then(|rp| rp.stream.as_ref());
     match stream_config {
@@ -2962,7 +2962,7 @@ mod tests {
 
         assert_eq!(
             get_effective_admission_strategies(&app_state),
-            vec![crate::model::AdmissionStrategy::GraceHoldStream]
+            vec![shared::model::AdmissionStrategy::GraceHoldStream]
         );
     }
 
@@ -3001,8 +3001,8 @@ mod tests {
             throttle_kbps: 0,
             shared_burst_buffer_mb: 1,
             admission_strategies: Some(vec![
-                crate::model::AdmissionStrategy::GraceHoldStream,
-                crate::model::AdmissionStrategy::EvictUserSameIpOldest,
+                AdmissionStrategy::GraceHoldStream,
+                AdmissionStrategy::EvictUserSameIpOldest,
             ]),
         });
 

--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -58,6 +58,69 @@ use tokio::{
 use tokio_util::io::ReaderStream;
 use url::Url;
 
+const RECENT_EVICTION_REENTRY_TTL_SECS: u64 = 3;
+
+#[derive(Clone, Copy)]
+pub(crate) enum EvictionReentryGuard<'a> {
+    Session(&'a str),
+    SocketPlayback { virtual_id: VirtualId },
+}
+
+async fn should_suppress_eviction_for_recent_request(
+    app_state: &Arc<AppState>,
+    username: &str,
+    client_ip: &str,
+    guard: EvictionReentryGuard<'_>,
+    target_addr: &std::net::SocketAddr,
+) -> bool {
+    match guard {
+        EvictionReentryGuard::Session(session_token) => app_state
+            .active_users
+            .recently_evicted_session_protected_addr(session_token)
+            .await
+            .is_some_and(|protected_addr| protected_addr == *target_addr),
+        EvictionReentryGuard::SocketPlayback { virtual_id } => app_state
+            .active_users
+            .recent_socket_reentry_protected_addr(username, client_ip, virtual_id)
+            .await
+            .is_some_and(|protected_addr| protected_addr == *target_addr),
+    }
+}
+
+async fn get_admission_for_request(
+    app_state: &Arc<AppState>,
+    username: &str,
+    max_connections: u32,
+    soft_connections: u16,
+    is_session_request: bool,
+    session_token: Option<&str>,
+    activate_unbound_session: bool,
+) -> crate::api::model::ConnectionAdmission {
+    if is_session_request {
+        if activate_unbound_session {
+            app_state
+                .get_connection_admission_for_session_activation(
+                    username,
+                    max_connections,
+                    soft_connections,
+                    session_token.unwrap_or_default(),
+                )
+                .await
+        } else {
+            app_state
+                .get_connection_admission_for_session(
+                    username,
+                    max_connections,
+                    soft_connections,
+                    session_token.unwrap_or_default(),
+                )
+                .await
+        }
+    } else {
+        app_state.get_connection_admission(username, max_connections, soft_connections).await
+    }
+}
+
 pub(crate) fn resolve_request_url_for_logging<'a>(input: &ConfigInput, stream_url: &'a str) -> Cow<'a, str> {
     if is_sanitize_sensitive_info_enabled() {
         return Cow::Borrowed(stream_url);
@@ -476,37 +539,25 @@ pub(in crate::api) async fn resolve_admission_with_strategies(
     max_connections: u32,
     soft_connections: u16,
     client_ip: &str,
-    _fingerprint: &Fingerprint,
+    request_addr: &std::net::SocketAddr,
     is_session_request: bool,
     session_token: Option<&str>,
     activate_unbound_session: bool,
+    eviction_reentry_guard: EvictionReentryGuard<'_>,
 ) -> (crate::api::model::ConnectionAdmission, Option<crate::api::model::GraceMode>) {
     use crate::api::model::{AdmissionDecision, ConnectionAdmission, ConnectionKind, StrategyContext, evaluate_strategy};
     use shared::model::UserConnectionPermission;
 
-    let admission = if is_session_request {
-        if activate_unbound_session {
-            app_state
-                .get_connection_admission_for_session_activation(
-                    username,
-                    max_connections,
-                    soft_connections,
-                    session_token.unwrap_or_default(),
-                )
-                .await
-        } else {
-            app_state
-                .get_connection_admission_for_session(
-                    username,
-                    max_connections,
-                    soft_connections,
-                    session_token.unwrap_or_default(),
-                )
-                .await
-        }
-    } else {
-        app_state.get_connection_admission(username, max_connections, soft_connections).await
-    };
+    let admission = get_admission_for_request(
+        app_state,
+        username,
+        max_connections,
+        soft_connections,
+        is_session_request,
+        session_token,
+        activate_unbound_session,
+    )
+    .await;
 
     if admission.permission != UserConnectionPermission::Exhausted {
         return (admission, None);
@@ -536,33 +587,37 @@ pub(in crate::api) async fn resolve_admission_with_strategies(
                 debug!("Grace grant rejected for user {username}, continuing with later strategies");
             }
             AdmissionDecision::Evict(target) => {
+                if should_suppress_eviction_for_recent_request(
+                    app_state,
+                    username,
+                    client_ip,
+                    eviction_reentry_guard,
+                    &target.addr,
+                )
+                .await
+                {
+                    debug!(
+                        "Skipping eviction strategy {strategy:?} for recently evicted request of user {username} targeting {}",
+                        target.addr
+                    );
+                    continue;
+                }
                 debug!("Evicting connection {} for user {username}", target.addr);
+                app_state
+                    .active_users
+                    .mark_recent_eviction_guard_for_addr(&target.addr, *request_addr, RECENT_EVICTION_REENTRY_TTL_SECS)
+                    .await;
                 app_state.connection_manager.release_connection_as_kicked(&target.addr).await;
-                let retry_admission = if is_session_request {
-                    if activate_unbound_session {
-                        app_state
-                            .get_connection_admission_for_session_activation(
-                                username,
-                                max_connections,
-                                soft_connections,
-                                session_token.unwrap_or_default(),
-                            )
-                            .await
-                    } else {
-                        app_state
-                            .get_connection_admission_for_session(
-                                username,
-                                max_connections,
-                                soft_connections,
-                                session_token.unwrap_or_default(),
-                            )
-                            .await
-                    }
-                } else {
-                    app_state
-                        .get_connection_admission(username, max_connections, soft_connections)
-                        .await
-                };
+                let retry_admission = get_admission_for_request(
+                    app_state,
+                    username,
+                    max_connections,
+                    soft_connections,
+                    is_session_request,
+                    session_token,
+                    activate_unbound_session,
+                )
+                .await;
                 if retry_admission.permission == UserConnectionPermission::Allowed {
                     return (retry_admission, None);
                 }
@@ -638,10 +693,11 @@ async fn activate_session_before_stream_open(
         user.max_connections,
         user.soft_connections,
         &fingerprint.client_ip,
-        fingerprint,
+        &fingerprint.addr,
         true,
         Some(session_token),
         true,
+        EvictionReentryGuard::SocketPlayback { virtual_id },
     )
     .await;
 
@@ -2848,6 +2904,10 @@ mod tests {
         Fingerprint::new(format!("fp-{addr}"), addr.ip().to_string(), addr)
     }
 
+    fn create_test_fingerprint_with_user_agent(addr: std::net::SocketAddr, user_agent: &str) -> Fingerprint {
+        Fingerprint::new(format!("{}|{user_agent}", addr.ip()), addr.ip().to_string(), addr)
+    }
+
     fn create_test_app_state_with_stream_config(stream: crate::model::StreamConfig) -> Arc<AppState> {
         let mut config = Config::default();
         config.reverse_proxy = Some(crate::model::ReverseProxyConfig {
@@ -3058,16 +3118,385 @@ mod tests {
             1,
             1,
             "127.0.0.1",
-            &create_test_fingerprint("127.0.0.1:55153".parse().unwrap_or_else(|_| unreachable!())),
+            &"127.0.0.1:55153".parse().unwrap_or_else(|_| unreachable!()),
             true,
             Some("tok-third"),
             false,
+            EvictionReentryGuard::Session("tok-third"),
         )
         .await;
 
         assert_eq!(admission.permission, UserConnectionPermission::Allowed);
         assert_eq!(admission.kind, Some(crate::api::model::ConnectionKind::Soft));
         assert_eq!(grace_mode, None);
+    }
+
+    #[tokio::test]
+    async fn resolve_admission_with_strategies_prevents_recently_evicted_playback_ping_pong() {
+        let app_state = create_test_app_state_with_stream_config(crate::model::StreamConfig {
+            retry: true,
+            metrics_enabled: true,
+            buffer: None,
+            grace_period_millis: 0,
+            grace_period_timeout_secs: 8,
+            grace_period_hold_stream: false,
+            hls_session_ttl_secs: 10,
+            catchup_session_ttl_secs: 10,
+            throttle_str: None,
+            throttle_kbps: 0,
+            shared_burst_buffer_mb: 1,
+            admission_strategies: Some(vec![AdmissionStrategy::EvictUserOldest]),
+        });
+
+        let victim_addr: std::net::SocketAddr = "127.0.0.1:55181".parse().unwrap_or_else(|_| unreachable!());
+        let reconnect_addr: std::net::SocketAddr = "127.0.0.1:55182".parse().unwrap_or_else(|_| unreachable!());
+        let winner_addr: std::net::SocketAddr = "127.0.0.1:55183".parse().unwrap_or_else(|_| unreachable!());
+        let victim_fingerprint = create_test_fingerprint_with_user_agent(victim_addr, "player/1.0");
+        let reconnect_fingerprint = create_test_fingerprint_with_user_agent(reconnect_addr, "player/1.0");
+        let winner_fingerprint = create_test_fingerprint_with_user_agent(winner_addr, "winner/1.0");
+        let mut victim_channel = create_test_live_channel("http://provider-1.example/live/9001.ts");
+        victim_channel.virtual_id = 9001;
+        let mut winner_channel = create_test_live_channel("http://provider-1.example/live/9002.ts");
+        winner_channel.virtual_id = 9002;
+
+        app_state.connection_manager.add_connection(&victim_addr).await;
+        app_state.connection_manager.add_connection(&winner_addr).await;
+
+        app_state
+            .connection_manager
+            .update_connection(crate::api::model::ConnectionParams {
+                meter_uid: 1,
+                username: "loop-user",
+                max_connections: 2,
+                soft_connections: 0,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &victim_fingerprint,
+                provider: "provider-a",
+                stream_channel: &victim_channel,
+                user_agent: std::borrow::Cow::Borrowed("player/1.0"),
+                session_token: Some("session-victim"),
+            })
+            .await;
+        app_state
+            .connection_manager
+            .update_connection(crate::api::model::ConnectionParams {
+                meter_uid: 2,
+                username: "loop-user",
+                max_connections: 2,
+                soft_connections: 0,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &winner_fingerprint,
+                provider: "provider-a",
+                stream_channel: &winner_channel,
+                user_agent: std::borrow::Cow::Borrowed("winner/1.0"),
+                session_token: Some("session-winner"),
+            })
+            .await;
+
+        app_state
+            .active_users
+            .mark_recent_eviction_guard_for_addr(&victim_addr, winner_addr, RECENT_EVICTION_REENTRY_TTL_SECS)
+            .await;
+        app_state.connection_manager.release_connection_as_kicked(&victim_addr).await;
+
+        let (admission, grace_mode) = resolve_admission_with_strategies(
+            &app_state,
+            "loop-user",
+            1,
+            0,
+            &reconnect_fingerprint.client_ip,
+            &reconnect_fingerprint.addr,
+            true,
+            Some("socket-reconnect"),
+            false,
+            EvictionReentryGuard::SocketPlayback { virtual_id: 9001 },
+        )
+        .await;
+
+        assert_eq!(admission.permission, UserConnectionPermission::Exhausted);
+        assert_eq!(grace_mode, None);
+        let active_streams = app_state.active_users.active_streams().await;
+        assert_eq!(active_streams.len(), 1);
+        assert_eq!(active_streams[0].channel.virtual_id, 9002);
+    }
+
+    #[tokio::test]
+    async fn resolve_admission_with_strategies_allows_other_channel_after_recent_eviction() {
+        let app_state = create_test_app_state_with_stream_config(crate::model::StreamConfig {
+            retry: true,
+            metrics_enabled: true,
+            buffer: None,
+            grace_period_millis: 0,
+            grace_period_timeout_secs: 8,
+            grace_period_hold_stream: false,
+            hls_session_ttl_secs: 10,
+            catchup_session_ttl_secs: 10,
+            throttle_str: None,
+            throttle_kbps: 0,
+            shared_burst_buffer_mb: 1,
+            admission_strategies: Some(vec![AdmissionStrategy::EvictUserOldest]),
+        });
+
+        let victim_addr: std::net::SocketAddr = "127.0.0.1:55184".parse().unwrap_or_else(|_| unreachable!());
+        let winner_addr: std::net::SocketAddr = "127.0.0.1:55185".parse().unwrap_or_else(|_| unreachable!());
+        let new_addr: std::net::SocketAddr = "127.0.0.1:55186".parse().unwrap_or_else(|_| unreachable!());
+        let victim_fingerprint = create_test_fingerprint_with_user_agent(victim_addr, "player/1.0");
+        let winner_fingerprint = create_test_fingerprint_with_user_agent(winner_addr, "winner/1.0");
+        let new_fingerprint = create_test_fingerprint_with_user_agent(new_addr, "player/1.0");
+        let mut victim_channel = create_test_live_channel("http://provider-1.example/live/9101.ts");
+        victim_channel.virtual_id = 9101;
+        let mut winner_channel = create_test_live_channel("http://provider-1.example/live/9102.ts");
+        winner_channel.virtual_id = 9102;
+
+        app_state.connection_manager.add_connection(&victim_addr).await;
+        app_state.connection_manager.add_connection(&winner_addr).await;
+
+        app_state
+            .connection_manager
+            .update_connection(crate::api::model::ConnectionParams {
+                meter_uid: 1,
+                username: "loop-user-2",
+                max_connections: 2,
+                soft_connections: 0,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &victim_fingerprint,
+                provider: "provider-a",
+                stream_channel: &victim_channel,
+                user_agent: std::borrow::Cow::Borrowed("player/1.0"),
+                session_token: Some("session-victim"),
+            })
+            .await;
+        app_state
+            .connection_manager
+            .update_connection(crate::api::model::ConnectionParams {
+                meter_uid: 2,
+                username: "loop-user-2",
+                max_connections: 2,
+                soft_connections: 0,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &winner_fingerprint,
+                provider: "provider-a",
+                stream_channel: &winner_channel,
+                user_agent: std::borrow::Cow::Borrowed("winner/1.0"),
+                session_token: Some("session-winner"),
+            })
+            .await;
+
+        app_state
+            .active_users
+            .mark_recent_eviction_guard_for_addr(&victim_addr, winner_addr, RECENT_EVICTION_REENTRY_TTL_SECS)
+            .await;
+        app_state.connection_manager.release_connection_as_kicked(&victim_addr).await;
+
+        let (admission, _grace_mode) = resolve_admission_with_strategies(
+            &app_state,
+            "loop-user-2",
+            1,
+            0,
+            &new_fingerprint.client_ip,
+            &new_fingerprint.addr,
+            true,
+            Some("session-new"),
+            false,
+            EvictionReentryGuard::SocketPlayback { virtual_id: 9103 },
+        )
+        .await;
+
+        assert_eq!(admission.permission, UserConnectionPermission::Allowed);
+        assert!(app_state.active_users.active_streams().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_admission_with_strategies_does_not_suppress_different_session_on_same_channel() {
+        let app_state = create_test_app_state_with_stream_config(crate::model::StreamConfig {
+            retry: true,
+            metrics_enabled: true,
+            buffer: None,
+            grace_period_millis: 0,
+            grace_period_timeout_secs: 8,
+            grace_period_hold_stream: false,
+            hls_session_ttl_secs: 10,
+            catchup_session_ttl_secs: 10,
+            throttle_str: None,
+            throttle_kbps: 0,
+            shared_burst_buffer_mb: 1,
+            admission_strategies: Some(vec![AdmissionStrategy::EvictUserOldest]),
+        });
+
+        let victim_addr: std::net::SocketAddr = "127.0.0.1:55190".parse().unwrap_or_else(|_| unreachable!());
+        let winner_addr: std::net::SocketAddr = "127.0.0.1:55191".parse().unwrap_or_else(|_| unreachable!());
+        let new_addr: std::net::SocketAddr = "127.0.0.1:55192".parse().unwrap_or_else(|_| unreachable!());
+        let victim_fingerprint = create_test_fingerprint_with_user_agent(victim_addr, "player/1.0");
+        let winner_fingerprint = create_test_fingerprint_with_user_agent(winner_addr, "player/1.0");
+        let new_fingerprint = create_test_fingerprint_with_user_agent(new_addr, "player/1.0");
+        let mut channel = create_test_live_channel("http://provider-1.example/live/9301.m3u8");
+        channel.virtual_id = 9301;
+        channel.item_type = PlaylistItemType::LiveHls;
+
+        app_state.connection_manager.add_connection(&victim_addr).await;
+        app_state.connection_manager.add_connection(&winner_addr).await;
+
+        app_state
+            .connection_manager
+            .update_connection(crate::api::model::ConnectionParams {
+                meter_uid: 1,
+                username: "loop-user-4",
+                max_connections: 2,
+                soft_connections: 0,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &victim_fingerprint,
+                provider: "provider-a",
+                stream_channel: &channel,
+                user_agent: std::borrow::Cow::Borrowed("player/1.0"),
+                session_token: Some("session-victim"),
+            })
+            .await;
+        app_state
+            .connection_manager
+            .update_connection(crate::api::model::ConnectionParams {
+                meter_uid: 2,
+                username: "loop-user-4",
+                max_connections: 2,
+                soft_connections: 0,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &winner_fingerprint,
+                provider: "provider-a",
+                stream_channel: &channel,
+                user_agent: std::borrow::Cow::Borrowed("player/1.0"),
+                session_token: Some("session-winner"),
+            })
+            .await;
+
+        app_state
+            .active_users
+            .mark_recent_eviction_guard_for_addr(&victim_addr, winner_addr, RECENT_EVICTION_REENTRY_TTL_SECS)
+            .await;
+        app_state.connection_manager.release_connection_as_kicked(&victim_addr).await;
+
+        let (admission, grace_mode) = resolve_admission_with_strategies(
+            &app_state,
+            "loop-user-4",
+            1,
+            0,
+            &new_fingerprint.client_ip,
+            &new_fingerprint.addr,
+            true,
+            Some("session-other"),
+            false,
+            EvictionReentryGuard::Session("session-other"),
+        )
+        .await;
+
+        assert_eq!(admission.permission, UserConnectionPermission::Allowed);
+        assert_eq!(grace_mode, None);
+        assert!(app_state.active_users.active_streams().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_admission_with_strategies_allows_recently_evicted_playback_when_soft_slot_is_free() {
+        let app_state = create_test_app_state_with_stream_config(crate::model::StreamConfig {
+            retry: true,
+            metrics_enabled: true,
+            buffer: None,
+            grace_period_millis: 0,
+            grace_period_timeout_secs: 8,
+            grace_period_hold_stream: false,
+            hls_session_ttl_secs: 10,
+            catchup_session_ttl_secs: 10,
+            throttle_str: None,
+            throttle_kbps: 0,
+            shared_burst_buffer_mb: 1,
+            admission_strategies: Some(vec![AdmissionStrategy::EvictUserOldest]),
+        });
+
+        let victim_addr: std::net::SocketAddr = "127.0.0.1:55187".parse().unwrap_or_else(|_| unreachable!());
+        let reconnect_addr: std::net::SocketAddr = "127.0.0.1:55188".parse().unwrap_or_else(|_| unreachable!());
+        let winner_addr: std::net::SocketAddr = "127.0.0.1:55189".parse().unwrap_or_else(|_| unreachable!());
+        let victim_fingerprint = create_test_fingerprint_with_user_agent(victim_addr, "player/1.0");
+        let reconnect_fingerprint = create_test_fingerprint_with_user_agent(reconnect_addr, "player/1.0");
+        let winner_fingerprint = create_test_fingerprint_with_user_agent(winner_addr, "winner/1.0");
+        let mut victim_channel = create_test_live_channel("http://provider-1.example/live/9201.ts");
+        victim_channel.virtual_id = 9201;
+        let mut winner_channel = create_test_live_channel("http://provider-1.example/live/9202.ts");
+        winner_channel.virtual_id = 9202;
+
+        app_state.connection_manager.add_connection(&victim_addr).await;
+        app_state.connection_manager.add_connection(&winner_addr).await;
+
+        app_state
+            .connection_manager
+            .update_connection(crate::api::model::ConnectionParams {
+                meter_uid: 1,
+                username: "loop-user-3",
+                max_connections: 2,
+                soft_connections: 0,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &victim_fingerprint,
+                provider: "provider-a",
+                stream_channel: &victim_channel,
+                user_agent: std::borrow::Cow::Borrowed("player/1.0"),
+                session_token: Some("session-victim"),
+            })
+            .await;
+        app_state
+            .connection_manager
+            .update_connection(crate::api::model::ConnectionParams {
+                meter_uid: 2,
+                username: "loop-user-3",
+                max_connections: 2,
+                soft_connections: 0,
+                connection_kind: crate::api::model::ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &winner_fingerprint,
+                provider: "provider-a",
+                stream_channel: &winner_channel,
+                user_agent: std::borrow::Cow::Borrowed("winner/1.0"),
+                session_token: Some("session-winner"),
+            })
+            .await;
+
+        app_state
+            .active_users
+            .mark_recent_eviction_guard_for_addr(&victim_addr, winner_addr, RECENT_EVICTION_REENTRY_TTL_SECS)
+            .await;
+        app_state.connection_manager.release_connection_as_kicked(&victim_addr).await;
+
+        let (admission, grace_mode) = resolve_admission_with_strategies(
+            &app_state,
+            "loop-user-3",
+            1,
+            1,
+            &reconnect_fingerprint.client_ip,
+            &reconnect_fingerprint.addr,
+            true,
+            Some("socket-reconnect"),
+            false,
+            EvictionReentryGuard::SocketPlayback { virtual_id: 9201 },
+        )
+        .await;
+
+        assert_eq!(admission.permission, UserConnectionPermission::Allowed);
+        assert_eq!(admission.kind, Some(crate::api::model::ConnectionKind::Soft));
+        assert_eq!(grace_mode, None);
+
+        let active_streams = app_state.active_users.active_streams().await;
+        assert_eq!(active_streams.len(), 1);
+        assert_eq!(active_streams[0].channel.virtual_id, 9202);
     }
 
     #[tokio::test]
@@ -3611,10 +4040,11 @@ mod tests {
             user.max_connections,
             user.soft_connections,
             &first_fingerprint.client_ip,
-            &first_fingerprint,
+            &first_fingerprint.addr,
             true,
             Some("tok-hls-first"),
             true,
+            EvictionReentryGuard::Session("tok-hls-first"),
         )
         .await
         .0;
@@ -3624,10 +4054,11 @@ mod tests {
             user.max_connections,
             user.soft_connections,
             &second_fingerprint.client_ip,
-            &second_fingerprint,
+            &second_fingerprint.addr,
             true,
             Some("tok-hls-second"),
             true,
+            EvictionReentryGuard::Session("tok-hls-second"),
         )
         .await
         .0;

--- a/backend/src/api/api_utils.rs
+++ b/backend/src/api/api_utils.rs
@@ -3806,4 +3806,60 @@ mod tests {
         assert!(logical.contains(&fingerprint.key));
         assert!(socket_bound.contains(&fingerprint.addr.to_string()));
     }
+
+    #[tokio::test]
+    async fn get_query_path_strips_extension_for_live_with_flag() {
+        use crate::model::ConfigInputFlags;
+        use shared::model::{InputType, PlaylistItemType, XtreamCluster, XtreamPlaylistItem};
+
+        let mut input = ConfigInput {
+            id: 1,
+            name: "provider_with_flag".intern(),
+            input_type: InputType::Xtream,
+            ..ConfigInput::default()
+        };
+        let mut options = crate::model::ConfigInputOptions::defaults().clone();
+        options.flags.set(ConfigInputFlags::XtreamLiveStreamWithoutExtension);
+        input.options = Some(options);
+
+        let sources = SourcesConfig { inputs: vec![Arc::new(input)], ..SourcesConfig::default() };
+        let mut app_cfg_raw = create_test_app_config();
+        app_cfg_raw.sources = Arc::new(ArcSwap::from_pointee(sources));
+        let app_state = create_test_app_state_for_config(Arc::new(app_cfg_raw));
+
+        let pli = XtreamPlaylistItem {
+            virtual_id: 100,
+            provider_id: 1,
+            name: "test".intern(),
+            logo: "".intern(),
+            logo_small: "".intern(),
+            group: "".intern(),
+            title: "".intern(),
+            parent_code: "".intern(),
+            rec: "".intern(),
+            url: "http://example.com/123".intern(),
+            epg_channel_id: None,
+            xtream_cluster: XtreamCluster::Live,
+            additional_properties: None,
+            item_type: PlaylistItemType::Live,
+            category_id: 0,
+            input_name: "provider_with_flag".intern(),
+            channel_no: 0,
+            source_ordinal: 0,
+        };
+
+        let hls_ext = shared::utils::HLS_EXT.to_string();
+        let (query_path, extension) =
+            crate::api::endpoints::xtream_api::get_query_path("", Some(&hls_ext), &pli, &app_state);
+
+        assert_eq!(extension, "");
+        assert_eq!(query_path, "1");
+
+        let dash_ext = shared::utils::DASH_EXT.to_string();
+        let (query_path, extension) =
+            crate::api::endpoints::xtream_api::get_query_path("", Some(&dash_ext), &pli, &app_state);
+
+        assert_eq!(extension, "");
+        assert_eq!(query_path, "1");
+    }
 }

--- a/backend/src/api/endpoints/hls_api.rs
+++ b/backend/src/api/endpoints/hls_api.rs
@@ -478,10 +478,11 @@ async fn hls_api_stream(
                 user.max_connections,
                 user.soft_connections,
                 &fingerprint.client_ip,
-                &fingerprint,
+                &fingerprint.addr,
                 true,
                 Some(&session.token),
                 true,
+                crate::api::api_utils::EvictionReentryGuard::Session(&session.token),
             )
             .await
         } else {

--- a/backend/src/api/endpoints/hls_api.rs
+++ b/backend/src/api/endpoints/hls_api.rs
@@ -178,7 +178,7 @@ pub(in crate::api) async fn handle_hls_stream_request(
             None => (url, None, None),
         }
     } else {
-        let user_session_token = create_session_fingerprint(fingerprint, &user.username, virtual_id);
+        let user_session_token = create_session_fingerprint(fingerprint, &user.username, virtual_id, false);
         match app_state
             .active_provider
             .acquire_connection_with_grace_for_session(
@@ -279,6 +279,12 @@ pub(in crate::api) async fn handle_hls_stream_request(
         }
         Err(err) => {
             error!("Failed to download m3u8 {}", sanitize_sensitive_info(err.to_string().as_str()));
+            if let Some(session_token) = session_token.as_deref() {
+                app_state
+                    .active_users
+                    .release_unbound_session_reservation(&user.username, session_token, false)
+                    .await;
+            }
 
             let custom_stream_response = app_state.app_config.custom_stream_response.load();
             if custom_stream_response.as_ref().and_then(|c| c.channel_unavailable.as_ref()).is_some() {
@@ -395,7 +401,7 @@ async fn hls_api_stream(
     let lookup_session_token = decoded_hls_token
         .0
         .clone()
-        .unwrap_or_else(|| create_session_fingerprint(&fingerprint, &user.username, virtual_id));
+        .unwrap_or_else(|| create_session_fingerprint(&fingerprint, &user.username, virtual_id, false));
     let mut user_session = app_state
         .active_users
         .get_and_update_user_session(&user.username, &lookup_session_token)
@@ -438,8 +444,7 @@ async fn hls_api_stream(
         if session.virtual_id == virtual_id {
             app_state
                 .connection_manager
-                .touch_http_activity(&user.username, &session.token, &fingerprint.addr)
-                .await;
+                .touch_http_activity(&user.username, &session.token, &fingerprint.addr);
             let stream_channel = resolve_stream_channel(&app_state, &target, &input, virtual_id, &hls_url).await;
             if is_seek_request(stream_channel.cluster, &req_headers).await {
                 // partial request means we are in reverse proxy mode, seek happened
@@ -475,6 +480,7 @@ async fn hls_api_stream(
                 &fingerprint,
                 true,
                 Some(&session.token),
+                true,
             )
             .await
         } else {
@@ -491,6 +497,8 @@ async fn hls_api_stream(
             .kind
             .or(session.connection_kind)
             .unwrap_or(crate::api::model::ConnectionKind::Normal);
+        session.permission = connection_permission;
+        session.connection_kind = Some(connection_kind);
         if connection_permission == UserConnectionPermission::Exhausted {
             let stream_channel = resolve_stream_channel(&app_state, &target, &input, virtual_id, &session.stream_url).await;
             return admission_failure_response(

--- a/backend/src/api/endpoints/hls_api.rs
+++ b/backend/src/api/endpoints/hls_api.rs
@@ -444,7 +444,8 @@ async fn hls_api_stream(
         if session.virtual_id == virtual_id {
             app_state
                 .connection_manager
-                .touch_http_activity(&user.username, &session.token, &fingerprint.addr);
+                .touch_http_activity(&user.username, &session.token, &fingerprint.addr)
+                .await;
             let stream_channel = resolve_stream_channel(&app_state, &target, &input, virtual_id, &hls_url).await;
             if is_seek_request(stream_channel.cluster, &req_headers).await {
                 // partial request means we are in reverse proxy mode, seek happened

--- a/backend/src/api/endpoints/m3u_api.rs
+++ b/backend/src/api/endpoints/m3u_api.rs
@@ -3,7 +3,7 @@ use crate::{
         api_utils::{
             create_catchup_session_key, create_session_fingerprint, force_provider_stream_response,
             get_session_reservation_ttl_secs, get_user_target, get_user_target_by_credentials, is_seek_request,
-            is_stream_share_enabled, local_stream_response, redirect, redirect_response, resource_response,
+            is_session_based_playback, is_stream_share_enabled, local_stream_response, redirect, redirect_response, resource_response,
             admission_failure_response, separate_number_and_remainder, should_allow_exhausted_shared_reconnect, stream_response,
             try_option_bad_request, try_option_forbidden, try_result_bad_request, try_result_not_found,
             try_unwrap_body, RedirectParams,
@@ -24,7 +24,7 @@ use futures::StreamExt;
 use log::{debug, error};
 use shared::{
     model::{FieldGetAccessor, PlaylistEntry, PlaylistItemType, TargetType, UserConnectionPermission, XtreamCluster},
-    utils::{concat_path, extract_extension_from_url, sanitize_sensitive_info, HLS_EXT},
+    utils::{concat_path, extract_extension_from_url, sanitize_sensitive_info},
 };
 use std::sync::Arc;
 
@@ -132,7 +132,7 @@ async fn m3u_api_stream(
     }
 
     if pli.item_type.is_local() {
-        let playback_session_token = create_session_fingerprint(fingerprint, &user.username, virtual_id);
+        let playback_session_token = create_session_fingerprint(fingerprint, &user.username, virtual_id, true);
         let (admission, _grace_mode) = if (user.max_connections > 0 || user.soft_connections > 0)
             && app_state.app_config.config.load().user_access_control
         {
@@ -145,6 +145,7 @@ async fn m3u_api_stream(
                 fingerprint,
                 true,
                 Some(playback_session_token.as_str()),
+                false,
             )
             .await
         } else {
@@ -178,10 +179,16 @@ async fn m3u_api_stream(
     debug_if_enabled!(
         "ID chain for m3u endpoint: request_stream_id={} -> action_stream_id={action_stream_id} -> req_virtual_id={req_virtual_id} -> virtual_id={virtual_id}",
         stream_req.stream_id);
+    let extension = stream_ext.clone().unwrap_or_else(|| extract_extension_from_url(&pli.url).unwrap_or_default());
     let session_key = if pli.item_type == PlaylistItemType::Catchup {
         create_catchup_session_key(fingerprint, &user.username, virtual_id)
     } else {
-        create_session_fingerprint(fingerprint, &user.username, virtual_id)
+        create_session_fingerprint(
+            fingerprint,
+            &user.username,
+            virtual_id,
+            !is_session_based_playback(pli.item_type, Some(extension.as_str())),
+        )
     };
     let user_session = app_state.active_users.get_and_update_user_session(&user.username, &session_key).await;
 
@@ -244,6 +251,7 @@ async fn m3u_api_stream(
             fingerprint,
             true,
             Some(&session_key),
+            false,
         )
         .await
     } else {
@@ -297,11 +305,7 @@ async fn m3u_api_stream(
         return response.into_response();
     }
 
-    let extension = stream_ext.unwrap_or_else(|| extract_extension_from_url(&pli.url).unwrap_or_default());
-
-    let is_hls_request = pli.item_type == PlaylistItemType::LiveHls
-        || pli.item_type == PlaylistItemType::LiveDash
-        || extension == HLS_EXT;
+    let is_hls_request = is_session_based_playback(pli.item_type, Some(extension.as_str()));
     // Reverse proxy mode
     if is_hls_request {
         return handle_hls_stream_request(

--- a/backend/src/api/endpoints/m3u_api.rs
+++ b/backend/src/api/endpoints/m3u_api.rs
@@ -142,10 +142,13 @@ async fn m3u_api_stream(
                 user.max_connections,
                 user.soft_connections,
                 &fingerprint.client_ip,
-                fingerprint,
+                &fingerprint.addr,
                 true,
                 Some(playback_session_token.as_str()),
                 false,
+                crate::api::api_utils::EvictionReentryGuard::SocketPlayback {
+                    virtual_id: pli.virtual_id,
+                },
             )
             .await
         } else {
@@ -189,6 +192,13 @@ async fn m3u_api_stream(
             virtual_id,
             !is_session_based_playback(pli.item_type, Some(extension.as_str())),
         )
+    };
+    let eviction_reentry_guard = if pli.item_type == PlaylistItemType::Catchup
+        || is_session_based_playback(pli.item_type, Some(extension.as_str()))
+    {
+        crate::api::api_utils::EvictionReentryGuard::Session(&session_key)
+    } else {
+        crate::api::api_utils::EvictionReentryGuard::SocketPlayback { virtual_id: pli.virtual_id }
     };
     let user_session = app_state.active_users.get_and_update_user_session(&user.username, &session_key).await;
 
@@ -248,10 +258,11 @@ async fn m3u_api_stream(
             user.max_connections,
             user.soft_connections,
             &fingerprint.client_ip,
-            fingerprint,
+            &fingerprint.addr,
             true,
             Some(&session_key),
             false,
+            eviction_reentry_guard,
         )
         .await
     } else {

--- a/backend/src/api/endpoints/m3u_api.rs
+++ b/backend/src/api/endpoints/m3u_api.rs
@@ -305,9 +305,9 @@ async fn m3u_api_stream(
         return response.into_response();
     }
 
-    let is_hls_request = is_session_based_playback(pli.item_type, Some(extension.as_str()));
-    // Reverse proxy mode
-    if is_hls_request {
+    let is_session_request = is_session_based_playback(pli.item_type, Some(extension.as_str()));
+    // Reverse proxy mode — only route genuine HLS into the HLS handler, not DASH
+    if is_session_request && extension == shared::utils::HLS_EXT {
         return handle_hls_stream_request(
             fingerprint,
             app_state,

--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -519,7 +519,7 @@ async fn xtream_player_api_stream(
     .into_response()
 }
 
-fn get_query_path(
+pub(crate) fn get_query_path(
     action_path: &str,
     stream_ext: Option<&String>,
     pli: &XtreamPlaylistItem,
@@ -609,10 +609,9 @@ async fn xtream_player_api_stream_with_token(
             .into_response();
         }
 
-        let stream_ext = stream_ext.filter(|s| !s.is_empty())
-            .or_else(|| pli.get_container_extension().map(|e| concat_string!(".", e.as_ref())));
+        let (query_path, extension) = get_query_path(stream_req.action_path, stream_ext.as_ref(), &pli, app_state);
 
-        let is_session_request = is_session_based_playback(pli.item_type, stream_ext.as_deref());
+        let is_session_request = is_session_based_playback(pli.item_type, Some(extension.as_str()));
         let session_key = create_session_fingerprint(
             fingerprint,
             "webui",
@@ -623,7 +622,7 @@ async fn xtream_player_api_stream_with_token(
         // TODO how should we use fixed provider for hls in multi provider config?
 
         // Reverse proxy mode — only route genuine HLS into the HLS handler, not DASH
-        if is_session_request && stream_ext.as_deref() == Some(shared::utils::HLS_EXT) {
+        if is_session_request && extension == shared::utils::HLS_EXT {
             return handle_hls_stream_request(
                 fingerprint,
                 app_state,
@@ -640,7 +639,7 @@ async fn xtream_player_api_stream_with_token(
             .into_response();
         }
 
-        let (query_path, _extension) = get_query_path(stream_req.action_path, stream_ext.as_ref(), &pli, app_state);
+
 
         let stream_url = try_option_bad_request!(
             get_xtream_player_api_stream_url(&input, stream_req.context, &query_path, &pli.url),

--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -294,10 +294,13 @@ async fn xtream_player_api_stream(
                 user.max_connections,
                 user.soft_connections,
                 &fingerprint.client_ip,
-                fingerprint,
+                &fingerprint.addr,
                 true,
                 Some(playback_session_token.as_str()),
                 false,
+                crate::api::api_utils::EvictionReentryGuard::SocketPlayback {
+                    virtual_id: pli.virtual_id,
+                },
             )
             .await
         } else {
@@ -349,6 +352,13 @@ async fn xtream_player_api_stream(
             virtual_id,
             !is_session_based_playback(item_type, Some(requested_extension.as_str())),
         )
+    };
+    let eviction_reentry_guard = if item_type == PlaylistItemType::Catchup
+        || is_session_based_playback(item_type, Some(requested_extension.as_str()))
+    {
+        crate::api::api_utils::EvictionReentryGuard::Session(&session_key)
+    } else {
+        crate::api::api_utils::EvictionReentryGuard::SocketPlayback { virtual_id }
     };
     let user_session = app_state.active_users.get_and_update_user_session(&user.username, &session_key).await;
 
@@ -412,10 +422,11 @@ async fn xtream_player_api_stream(
             user.max_connections,
             user.soft_connections,
             &fingerprint.client_ip,
-            fingerprint,
+            &fingerprint.addr,
             true,
             Some(&session_key),
             false,
+            eviction_reentry_guard,
         )
         .await
     } else {

--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -4,10 +4,11 @@ use crate::{
     api::{
         api_utils,
         api_utils::{
-            create_api_proxy_user, create_catchup_session_key, create_session_fingerprint, empty_json_response_as_array,
-            empty_json_response_as_object, force_provider_stream_response, get_session_reservation_ttl_secs,
+            create_api_proxy_user, create_catchup_session_key, create_session_fingerprint,
+            empty_json_response_as_array, empty_json_response_as_object, force_provider_stream_response, get_session_reservation_ttl_secs,
             get_user_target, get_user_target_by_credentials, internal_server_error, is_seek_request,
-            admission_failure_response, is_stream_share_enabled, local_stream_response, redirect, redirect_response, resource_response,
+            admission_failure_response, is_session_based_playback, is_stream_share_enabled, local_stream_response, redirect,
+            redirect_response, resource_response,
             separate_number_and_remainder, should_allow_exhausted_shared_reconnect, stream_response,
             try_option_bad_request, try_option_forbidden, try_result_bad_request, try_result_not_found,
             try_unwrap_body, RedirectParams,
@@ -53,7 +54,7 @@ use shared::{
     },
     utils::{
         deserialize_as_string, extract_extension_from_url, generate_provider_playlist_uuid, sanitize_sensitive_info, trim_slash,
-        Internable, HLS_EXT,
+        Internable,
     },
 };
 use std::{
@@ -283,7 +284,7 @@ async fn xtream_player_api_stream(
     }
 
     if pli.item_type.is_local() {
-        let playback_session_token = create_session_fingerprint(fingerprint, &user.username, virtual_id);
+        let playback_session_token = create_session_fingerprint(fingerprint, &user.username, virtual_id, true);
         let (admission, _grace_mode) = if (user.max_connections > 0 || user.soft_connections > 0)
             && app_state.app_config.config.load().user_access_control
         {
@@ -296,6 +297,7 @@ async fn xtream_player_api_stream(
                 fingerprint,
                 true,
                 Some(playback_session_token.as_str()),
+                false,
             )
             .await
         } else {
@@ -333,10 +335,20 @@ async fn xtream_player_api_stream(
     debug_if_enabled!(
         "ID chain for xtream endpoint: request_stream_id={} -> action_stream_id={action_stream_id} -> req_virtual_id={req_virtual_id} -> virtual_id={virtual_id}",
         stream_req.stream_id);
+    let requested_extension = stream_ext
+        .clone()
+        .filter(|ext| !ext.is_empty())
+        .or_else(|| pli.get_container_extension().map(|ext| ext.to_string()))
+        .unwrap_or_default();
     let session_key = if item_type == PlaylistItemType::Catchup {
         create_catchup_session_key(fingerprint, &user.username, virtual_id)
     } else {
-        create_session_fingerprint(fingerprint, &user.username, virtual_id)
+        create_session_fingerprint(
+            fingerprint,
+            &user.username,
+            virtual_id,
+            !is_session_based_playback(item_type, Some(requested_extension.as_str())),
+        )
     };
     let user_session = app_state.active_users.get_and_update_user_session(&user.username, &session_key).await;
 
@@ -403,6 +415,7 @@ async fn xtream_player_api_stream(
             fingerprint,
             true,
             Some(&session_key),
+            false,
         )
         .await
     } else {
@@ -466,8 +479,7 @@ async fn xtream_player_api_stream(
         )
     );
 
-    let is_hls_request =
-        item_type == PlaylistItemType::LiveHls || item_type == PlaylistItemType::LiveDash || extension == HLS_EXT;
+    let is_hls_request = is_session_based_playback(item_type, Some(extension.as_str()));
     // Reverse proxy mode
     if is_hls_request {
         return handle_hls_stream_request(
@@ -579,7 +591,7 @@ async fn xtream_player_api_stream_with_token(
         let user = create_api_proxy_user(app_state);
 
         if pli.item_type.is_local() {
-            let playback_session_token = create_session_fingerprint(fingerprint, "webui", virtual_id);
+            let playback_session_token = create_session_fingerprint(fingerprint, "webui", virtual_id, true);
             return local_stream_response(
                 fingerprint,
                 app_state,
@@ -600,9 +612,13 @@ async fn xtream_player_api_stream_with_token(
         let stream_ext = stream_ext.filter(|s| !s.is_empty())
             .or_else(|| pli.get_container_extension().map(|e| concat_string!(".", e.as_ref())));
 
-        let session_key = create_session_fingerprint(fingerprint, "webui", virtual_id);
-
-        let is_hls_request = pli.item_type == PlaylistItemType::LiveHls || stream_ext.as_deref() == Some(HLS_EXT);
+        let is_hls_request = is_session_based_playback(pli.item_type, stream_ext.as_deref());
+        let session_key = create_session_fingerprint(
+            fingerprint,
+            "webui",
+            virtual_id,
+            !is_session_based_playback(pli.item_type, stream_ext.as_deref()),
+        );
 
         // TODO how should we use fixed provider for hls in multi provider config?
 

--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -468,7 +468,7 @@ async fn xtream_player_api_stream(
         return response.into_response();
     }
 
-    let (query_path, extension) = get_query_path(stream_req.action_path, stream_ext.as_ref(), &pli, app_state);
+    let (query_path, _extension) = get_query_path(stream_req.action_path, stream_ext.as_ref(), &pli, app_state);
 
     let stream_url = try_option_bad_request!(
         get_xtream_player_api_stream_url(&input, stream_req.context, &query_path, &session_url),
@@ -479,9 +479,9 @@ async fn xtream_player_api_stream(
         )
     );
 
-    let is_session_request = is_session_based_playback(item_type, Some(extension.as_str()));
+    let is_session_request = is_session_based_playback(item_type, Some(requested_extension.as_str()));
     // Reverse proxy mode — only route genuine HLS into the HLS handler, not DASH
-    if is_session_request && extension == shared::utils::HLS_EXT {
+    if is_session_request && requested_extension == shared::utils::HLS_EXT {
         return handle_hls_stream_request(
             fingerprint,
             app_state,
@@ -609,9 +609,14 @@ async fn xtream_player_api_stream_with_token(
             .into_response();
         }
 
-        let (query_path, extension) = get_query_path(stream_req.action_path, stream_ext.as_ref(), &pli, app_state);
+        let requested_extension = stream_ext
+            .as_ref().filter(|s| !s.is_empty()).cloned()
+            .or_else(|| pli.get_container_extension().map(|e| concat_string!(".", e.as_ref())))
+            .unwrap_or_default();
 
-        let is_session_request = is_session_based_playback(pli.item_type, Some(extension.as_str()));
+        let (query_path, _extension) = get_query_path(stream_req.action_path, stream_ext.as_ref(), &pli, app_state);
+
+        let is_session_request = is_session_based_playback(pli.item_type, Some(requested_extension.as_str()));
         let session_key = create_session_fingerprint(
             fingerprint,
             "webui",
@@ -622,7 +627,7 @@ async fn xtream_player_api_stream_with_token(
         // TODO how should we use fixed provider for hls in multi provider config?
 
         // Reverse proxy mode — only route genuine HLS into the HLS handler, not DASH
-        if is_session_request && extension == shared::utils::HLS_EXT {
+        if is_session_request && requested_extension == shared::utils::HLS_EXT {
             return handle_hls_stream_request(
                 fingerprint,
                 app_state,
@@ -638,8 +643,6 @@ async fn xtream_player_api_stream_with_token(
             .await
             .into_response();
         }
-
-
 
         let stream_url = try_option_bad_request!(
             get_xtream_player_api_stream_url(&input, stream_req.context, &query_path, &pli.url),

--- a/backend/src/api/endpoints/xtream_api.rs
+++ b/backend/src/api/endpoints/xtream_api.rs
@@ -338,7 +338,7 @@ async fn xtream_player_api_stream(
     let requested_extension = stream_ext
         .clone()
         .filter(|ext| !ext.is_empty())
-        .or_else(|| pli.get_container_extension().map(|ext| ext.to_string()))
+        .or_else(|| pli.get_container_extension().map(|ext| concat_string!(".", ext.as_ref())))
         .unwrap_or_default();
     let session_key = if item_type == PlaylistItemType::Catchup {
         create_catchup_session_key(fingerprint, &user.username, virtual_id)
@@ -479,9 +479,9 @@ async fn xtream_player_api_stream(
         )
     );
 
-    let is_hls_request = is_session_based_playback(item_type, Some(extension.as_str()));
-    // Reverse proxy mode
-    if is_hls_request {
+    let is_session_request = is_session_based_playback(item_type, Some(extension.as_str()));
+    // Reverse proxy mode — only route genuine HLS into the HLS handler, not DASH
+    if is_session_request && extension == shared::utils::HLS_EXT {
         return handle_hls_stream_request(
             fingerprint,
             app_state,
@@ -612,18 +612,18 @@ async fn xtream_player_api_stream_with_token(
         let stream_ext = stream_ext.filter(|s| !s.is_empty())
             .or_else(|| pli.get_container_extension().map(|e| concat_string!(".", e.as_ref())));
 
-        let is_hls_request = is_session_based_playback(pli.item_type, stream_ext.as_deref());
+        let is_session_request = is_session_based_playback(pli.item_type, stream_ext.as_deref());
         let session_key = create_session_fingerprint(
             fingerprint,
             "webui",
             virtual_id,
-            !is_session_based_playback(pli.item_type, stream_ext.as_deref()),
+            !is_session_request,
         );
 
         // TODO how should we use fixed provider for hls in multi provider config?
 
-        // Reverse proxy mode
-        if is_hls_request {
+        // Reverse proxy mode — only route genuine HLS into the HLS handler, not DASH
+        if is_session_request && stream_ext.as_deref() == Some(shared::utils::HLS_EXT) {
             return handle_hls_stream_request(
                 fingerprint,
                 app_state,

--- a/backend/src/api/model/active_user_manager.rs
+++ b/backend/src/api/model/active_user_manager.rs
@@ -752,7 +752,7 @@ impl ActiveUserManager {
     pub(crate) async fn get_eviction_candidates(
         &self,
         username: &str,
-        client_ip: &str,
+        _client_ip: &str,
     ) -> Vec<crate::api::model::EvictionCandidate> {
         let connections = self.connections.read().await;
         let Some(connection_data) = connections.by_key.get(username) else {
@@ -768,7 +768,7 @@ impl ActiveUserManager {
         connection_data
             .streams
             .iter()
-            .filter(|stream| !stream.preserved && stream.client_ip == client_ip)
+            .filter(|stream| !stream.preserved)
             .filter(|stream| matches!(addr_counts.get(&stream.addr), Some(1)))
             .map(|s| crate::api::model::EvictionCandidate {
                 addr: s.addr,
@@ -1795,6 +1795,63 @@ mod tests {
         let candidates = manager.get_eviction_candidates("same-user", "127.0.0.1").await;
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].addr, unique_addr);
+    }
+
+    #[tokio::test]
+    async fn eviction_candidates_include_other_ips_for_user_wide_rules() {
+        let config = Config::default();
+        let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveUserManager::new(&config, &geoip, &event_manager);
+
+        let first_addr: SocketAddr = "127.0.0.1:55041".parse().unwrap();
+        let second_addr: SocketAddr = "127.0.0.1:55042".parse().unwrap();
+        let first_fp = Fingerprint::new("fp-user-wide-1".to_string(), "10.0.0.1".to_string(), first_addr);
+        let second_fp = Fingerprint::new("fp-user-wide-2".to_string(), "10.0.0.2".to_string(), second_addr);
+
+        manager.add_connection(&first_addr).await;
+        manager.add_connection(&second_addr).await;
+
+        manager
+            .update_connection(ActiveUserConnectionParams {
+                uid: 41,
+                meter_uid: 0,
+                username: "same-user",
+                max_connections: 2,
+                soft_connections: 0,
+                connection_kind: ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &first_fp,
+                provider: "provider-a",
+                stream_channel: &test_channel(1041),
+                user_agent: Cow::Borrowed("ua"),
+                session_token: Some("tok-41"),
+            })
+            .await;
+
+        manager
+            .update_connection(ActiveUserConnectionParams {
+                uid: 42,
+                meter_uid: 0,
+                username: "same-user",
+                max_connections: 2,
+                soft_connections: 0,
+                connection_kind: ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &second_fp,
+                provider: "provider-a",
+                stream_channel: &test_channel(1042),
+                user_agent: Cow::Borrowed("ua"),
+                session_token: Some("tok-42"),
+            })
+            .await;
+
+        let candidates = manager.get_eviction_candidates("same-user", "10.0.0.1").await;
+        assert_eq!(candidates.len(), 2);
+        assert!(candidates.iter().any(|candidate| candidate.addr == first_addr));
+        assert!(candidates.iter().any(|candidate| candidate.addr == second_addr));
     }
 
     #[tokio::test]

--- a/backend/src/api/model/active_user_manager.rs
+++ b/backend/src/api/model/active_user_manager.rs
@@ -81,6 +81,7 @@ pub struct UserSession {
     pub ts: u64,
     pub permission: UserConnectionPermission,
     pub connection_kind: Option<ConnectionKind>,
+    pub counted: bool,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -201,6 +202,35 @@ impl UserConnectionData {
             uid,
             new_priority,
         })
+    }
+
+    fn try_promote_soft_session_reservation(&mut self) -> bool {
+        if self.counts.normal >= self.max_connections || self.counts.soft == 0 {
+            return false;
+        }
+
+        let active_tokens = self
+            .streams
+            .iter()
+            .filter_map(|stream| stream.session_token.as_deref())
+            .collect::<HashSet<_>>();
+
+        let candidate_index = self.sessions.iter().position(|session| {
+            session.counted
+                && session.connection_kind == Some(ConnectionKind::Soft)
+                && !active_tokens.contains(session.token.as_str())
+        });
+
+        let Some(candidate_index) = candidate_index else {
+            return false;
+        };
+
+        self.counts.normal = self.counts.normal.saturating_add(1);
+        if self.counts.soft > 0 {
+            self.counts.soft -= 1;
+        }
+        self.sessions[candidate_index].connection_kind = Some(ConnectionKind::Normal);
+        true
     }
 }
 
@@ -462,6 +492,13 @@ impl ActiveUserManager {
                             }
                             promotion = Some(action);
                         }
+                        if let Some(session_token) = removed_stream
+                            .as_ref()
+                            .and_then(|stream| stream.session_token.as_deref())
+                        {
+                            Self::clear_session_counted_without_stream(connection_data, session_token);
+                        }
+                        while connection_data.try_promote_soft_session_reservation() {}
                     }
                 }
             }
@@ -516,6 +553,9 @@ impl ActiveUserManager {
                                         released_kinds.push(kind);
                                     }
                                     connection_data.stream_normal_priorities.remove(&stream_info.uid);
+                                    if let Some(token) = stream_info.session_token.as_ref() {
+                                        removed_session_tokens.insert(token.clone());
+                                    }
                                     removed_streams.push(stream_info);
                                 }
                             } else {
@@ -549,6 +589,10 @@ impl ActiveUserManager {
                         }
                         promotions.push(action);
                     }
+                    for session_token in &removed_session_tokens {
+                        Self::clear_session_counted_without_stream(connection_data, session_token);
+                    }
+                    while connection_data.try_promote_soft_session_reservation() {}
 
                     if connection_data.connections < connection_data.max_connections {
                         connection_data.granted_grace = false;
@@ -895,6 +939,7 @@ impl ActiveUserManager {
                 );
             }
 
+            let tracked_socket_count = user_connections.key_by_addr.len();
             let connection_data = user_connections
                 .by_key
                 .entry(username.to_string())
@@ -903,6 +948,13 @@ impl ActiveUserManager {
             connection_data.soft_connections = soft_connections;
 
             let user_agent_string = user_agent.to_string();
+            let reserved_session_kind = session_token.and_then(|token| {
+                connection_data
+                    .sessions
+                    .iter()
+                    .find(|session| session.token == token && session.counted)
+                    .map(|session| session.connection_kind.unwrap_or(connection_kind))
+            });
 
             let existing_stream_info = connection_data
                 .streams
@@ -948,8 +1000,17 @@ impl ActiveUserManager {
                 });
 
             if let Some(stream_info) = existing_stream_info {
+                if let Some(token) = session_token {
+                    if let Some(session) = connection_data.sessions.iter_mut().find(|session| session.token == token) {
+                        session.counted = true;
+                        if session.connection_kind.is_none() {
+                            session.connection_kind = Some(reserved_session_kind.unwrap_or(connection_kind));
+                        }
+                    }
+                }
                 stream_info
             } else {
+                let effective_connection_kind = reserved_session_kind.unwrap_or(connection_kind);
                 let country_code = self.lookup_country(&fingerprint.client_ip);
 
                 let stream_info = StreamInfo::new(
@@ -965,15 +1026,19 @@ impl ActiveUserManager {
                     session_token,
                 );
 
-                let tracked_socket_count = user_connections.key_by_addr.len();
-
-                if let Some(connection_data) = user_connections.by_key.get_mut(username) {
-                    connection_data.increment_kind(connection_kind);
-                    connection_data.streams.push(stream_info.clone());
-                    connection_data.stream_kinds.insert(stream_info.uid, connection_kind);
-                    connection_data.stream_normal_priorities.insert(stream_info.uid, priority);
-                    Self::log_connection_added(username, &fingerprint.addr, connection_data, tracked_socket_count);
+                if reserved_session_kind.is_none() {
+                    connection_data.increment_kind(effective_connection_kind);
                 }
+                connection_data.streams.push(stream_info.clone());
+                connection_data.stream_kinds.insert(stream_info.uid, effective_connection_kind);
+                connection_data.stream_normal_priorities.insert(stream_info.uid, priority);
+                if let Some(token) = session_token {
+                    if let Some(session) = connection_data.sessions.iter_mut().find(|session| session.token == token) {
+                        session.counted = true;
+                        session.connection_kind = Some(effective_connection_kind);
+                    }
+                }
+                Self::log_connection_added(username, &fingerprint.addr, connection_data, tracked_socket_count);
 
                 stream_info
             }
@@ -1042,6 +1107,7 @@ impl ActiveUserManager {
             ts: current_time_secs(),
             permission: connection_permission,
             connection_kind,
+            counted: false,
         }
     }
 
@@ -1049,7 +1115,204 @@ impl ActiveUserManager {
         if let Some(token) = stream.session_token.as_deref() {
             if let Some(session) = connection_data.sessions.iter_mut().find(|session| session.token == token) {
                 session.connection_kind = Some(ConnectionKind::Normal);
+                session.counted = true;
             }
+        }
+    }
+
+    fn session_has_stream(connection_data: &UserConnectionData, session_token: &str) -> bool {
+        connection_data
+            .streams
+            .iter()
+            .any(|stream| stream.session_token.as_deref() == Some(session_token))
+    }
+
+    fn clear_session_counted_without_stream(connection_data: &mut UserConnectionData, session_token: &str) {
+        if Self::session_has_stream(connection_data, session_token) {
+            return;
+        }
+        if let Some(session) = connection_data.sessions.iter_mut().find(|session| session.token == session_token) {
+            session.counted = false;
+        }
+    }
+
+    fn release_expired_session_reservations(connection_data: &mut UserConnectionData, now: u64) {
+        let expired_counted = connection_data
+            .sessions
+            .iter()
+            .filter(|session| session.counted)
+            .filter(|session| now.saturating_sub(session.ts) >= USER_CON_TTL)
+            .filter(|session| !Self::session_has_stream(connection_data, session.token.as_str()))
+            .map(|session| (session.token.clone(), session.connection_kind.unwrap_or(ConnectionKind::Normal)))
+            .collect::<Vec<_>>();
+
+        for (_, kind) in &expired_counted {
+            connection_data.decrement_kind(*kind);
+        }
+        for (token, _) in expired_counted {
+            Self::clear_session_counted_without_stream(connection_data, &token);
+        }
+        while connection_data.try_promote_soft_session_reservation() {}
+    }
+
+    pub(crate) async fn connection_admission_for_session_activation(
+        &self,
+        username: &str,
+        max_connections: u32,
+        soft_connections: u16,
+        session_token: &str,
+    ) -> ConnectionAdmission {
+        if max_connections == 0 && soft_connections == 0 {
+            return ConnectionAdmission {
+                permission: UserConnectionPermission::Allowed,
+                kind: Some(ConnectionKind::Normal),
+            };
+        }
+
+        let mut connections = self.connections.write().await;
+        let Some(connection_data) = connections.by_key.get_mut(username) else {
+            return ConnectionAdmission {
+                permission: UserConnectionPermission::Allowed,
+                kind: Some(ConnectionKind::Normal),
+            };
+        };
+        connection_data.max_connections = max_connections;
+        connection_data.soft_connections = soft_connections;
+
+        let Some(session_index) = connection_data.sessions.iter().position(|session| session.token == session_token) else {
+            return self.check_connection_admission(username, connection_data);
+        };
+
+        if connection_data.sessions[session_index].counted || Self::session_has_stream(connection_data, session_token) {
+            connection_data.sessions[session_index].counted = true;
+            return ConnectionAdmission {
+                permission: UserConnectionPermission::Allowed,
+                kind: connection_data.sessions[session_index]
+                    .connection_kind
+                    .or(Some(ConnectionKind::Normal)),
+            };
+        }
+
+        let admission = self.check_connection_admission(username, connection_data);
+        if admission.permission == UserConnectionPermission::Allowed {
+            let kind = admission.kind.unwrap_or(ConnectionKind::Normal);
+            connection_data.increment_kind(kind);
+            let session = &mut connection_data.sessions[session_index];
+            session.permission = admission.permission;
+            session.connection_kind = Some(kind);
+            session.counted = true;
+        }
+        admission
+    }
+
+    pub async fn ensure_user_session_placeholder(&self, request: CreateUserSessionParams<'_>) -> bool {
+        let CreateUserSessionParams {
+            user,
+            session_token,
+            virtual_id,
+            provider,
+            stream_url,
+            addr,
+            connection_permission,
+            connection_kind,
+        } = request;
+        self.gc();
+
+        let username = user.username.clone();
+        let mut user_connections = self.connections.write().await;
+        let connection_data = user_connections
+            .by_key
+            .entry(username)
+            .or_insert_with(|| UserConnectionData::new(0, user.max_connections, user.soft_connections));
+
+        if let Some(session) = connection_data.sessions.iter_mut().find(|session| session.token == session_token) {
+            session.ts = current_time_secs();
+            session.addr = *addr;
+            if session.connection_kind.is_none() {
+                session.connection_kind = connection_kind;
+            }
+            if session.permission == UserConnectionPermission::Exhausted {
+                session.permission = connection_permission;
+            }
+            return false;
+        }
+
+        connection_data.add_session(Self::new_user_session(
+            session_token,
+            virtual_id,
+            provider,
+            stream_url,
+            addr,
+            connection_permission,
+            connection_kind,
+        ));
+        true
+    }
+
+    pub async fn release_unbound_session_reservation(
+        &self,
+        username: &str,
+        session_token: &str,
+        remove_session_if_unbound: bool,
+    ) {
+        let (connection_changed, user_removed, promotions) = {
+            let mut user_connections = self.connections.write().await;
+            let Some(connection_data) = user_connections.by_key.get_mut(username) else {
+                return;
+            };
+
+            if Self::session_has_stream(connection_data, session_token) {
+                return;
+            }
+
+            let Some(session_index) = connection_data.sessions.iter().position(|session| session.token == session_token) else {
+                return;
+            };
+
+            let mut connection_changed = false;
+            if connection_data.sessions[session_index].counted {
+                let kind = connection_data.sessions[session_index]
+                    .connection_kind
+                    .unwrap_or(ConnectionKind::Normal);
+                connection_data.decrement_kind(kind);
+                connection_data.sessions[session_index].counted = false;
+                connection_changed = true;
+            }
+
+            if remove_session_if_unbound {
+                connection_data.sessions.swap_remove(session_index);
+            }
+
+            if connection_data.connections < connection_data.max_connections {
+                connection_data.granted_grace = false;
+                connection_data.grace_ts = 0;
+            }
+
+            let mut promotions = Vec::new();
+            while let Some(action) = connection_data.try_promote_soft_stream() {
+                let promoted_stream = connection_data.streams.iter().find(|stream| stream.uid == action.uid).cloned();
+                if let Some(stream) = promoted_stream.as_ref() {
+                    Self::promote_session_for_stream(connection_data, stream);
+                }
+                promotions.push(action);
+            }
+            while connection_data.try_promote_soft_session_reservation() {}
+
+            let user_removed = connection_data.connections == 0
+                && connection_data.streams.is_empty()
+                && connection_data.sessions.is_empty();
+            if user_removed {
+                user_connections.by_key.remove(username);
+            }
+
+            (connection_changed, user_removed, promotions)
+        };
+
+        if connection_changed || user_removed {
+            self.log_active_user().await;
+        }
+        for action in promotions {
+            self.emit_promotion_update(username, action).await;
         }
     }
 
@@ -1464,6 +1727,7 @@ impl ActiveUserManager {
 
                         if should_remove {
                             let addr = connection_data.streams[stream_idx].addr;
+                            let session_token = connection_data.streams[stream_idx].session_token.clone();
                             if self.cleanup_tx.get().is_some() {
                                 cleanup_events.push((addr, Box::new(connection_data.streams[stream_idx].clone())));
                             } else {
@@ -1482,6 +1746,10 @@ impl ActiveUserManager {
                                 }
                                 promotions.push((entry.username.clone(), action));
                             }
+                            if let Some(session_token) = session_token.as_deref() {
+                                Self::clear_session_counted_without_stream(connection_data, session_token);
+                            }
+                            while connection_data.try_promote_soft_session_reservation() {}
                             expiry_index.remove(&key);
                         } else if let Some(replacement_entry) = self.build_preserved_stream_expiry(
                             &entry.username,
@@ -1546,12 +1814,13 @@ impl ActiveUserManager {
             {
                 if let Ok(mut user_connections) = self.connections.try_write() {
                     user_connections.kicked.retain(|_, (expires_at, _)| *expires_at > now);
+                    for connection_data in user_connections.by_key.values_mut() {
+                        Self::release_expired_session_reservations(connection_data, now);
+                        connection_data.sessions.retain(|s| now.saturating_sub(s.ts) < USER_CON_TTL);
+                    }
                     user_connections.by_key.retain(|_k, v| {
                         v.connections > 0 || !v.streams.is_empty() || now.saturating_sub(v.ts) < USER_CON_TTL
                     });
-                    for connection_data in user_connections.by_key.values_mut() {
-                        connection_data.sessions.retain(|s| now.saturating_sub(s.ts) < USER_CON_TTL);
-                    }
                     user_connections.key_by_addr.retain(|_, registration| {
                         !(registration.username.is_empty() && now.saturating_sub(registration.ts) >= ANON_SOCKET_TTL)
                     });
@@ -3320,6 +3589,238 @@ mod tests {
         let connection_data = connections.by_key.get("user1").expect("active user entry must survive gc");
         assert_eq!(connection_data.connections, 1);
         assert_eq!(connection_data.streams.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn session_activation_reserves_first_hls_slot_before_stream_registration() {
+        let config = Config::default();
+        let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveUserManager::new(&config, &geoip, &event_manager);
+
+        let mut user = ProxyUserCredentials::default();
+        user.username = String::from("user-hls-reserve");
+        user.max_connections = 1;
+
+        let first_addr: SocketAddr = "127.0.0.1:55180".parse().unwrap();
+        let second_addr: SocketAddr = "127.0.0.1:55181".parse().unwrap();
+
+        manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-first",
+                virtual_id: 9201,
+                provider: "provider-a",
+                stream_url: "http://localhost/live-a.m3u8",
+                addr: &first_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(ConnectionKind::Normal),
+            })
+            .await;
+        manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-second",
+                virtual_id: 9202,
+                provider: "provider-a",
+                stream_url: "http://localhost/live-b.m3u8",
+                addr: &second_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(ConnectionKind::Normal),
+            })
+            .await;
+
+        let first_admission = manager
+            .connection_admission_for_session_activation(&user.username, user.max_connections, 0, "tok-first")
+            .await;
+        let second_admission = manager
+            .connection_admission_for_session_activation(&user.username, user.max_connections, 0, "tok-second")
+            .await;
+
+        assert_eq!(first_admission.permission, UserConnectionPermission::Allowed);
+        assert_eq!(first_admission.kind, Some(ConnectionKind::Normal));
+        assert_eq!(second_admission.permission, UserConnectionPermission::Exhausted);
+
+        let connections = manager.connections.read().await;
+        let connection_data = connections.by_key.get(&user.username).expect("user connection data");
+        assert_eq!(connection_data.connections, 1);
+        assert_eq!(connection_data.counts.normal, 1);
+        assert_eq!(connection_data.streams.len(), 0);
+        assert!(
+            connection_data
+                .sessions
+                .iter()
+                .find(|session| session.token == "tok-first")
+                .is_some_and(|session| session.counted)
+        );
+        assert!(
+            connection_data
+                .sessions
+                .iter()
+                .find(|session| session.token == "tok-second")
+                .is_some_and(|session| !session.counted)
+        );
+    }
+
+    #[tokio::test]
+    async fn binding_reserved_sessions_keeps_hard_and_soft_counts_stable() {
+        let config = Config::default();
+        let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveUserManager::new(&config, &geoip, &event_manager);
+
+        let mut user = ProxyUserCredentials::default();
+        user.username = String::from("user-hls-soft");
+        user.max_connections = 1;
+        user.soft_connections = 1;
+
+        let first_addr: SocketAddr = "127.0.0.1:55182".parse().unwrap();
+        let second_addr: SocketAddr = "127.0.0.1:55183".parse().unwrap();
+        let first_fingerprint = Fingerprint::new("fp-hls-1".to_string(), "127.0.0.1".to_string(), first_addr);
+        let second_fingerprint = Fingerprint::new("fp-hls-2".to_string(), "127.0.0.1".to_string(), second_addr);
+
+        manager.add_connection(&first_addr).await;
+        manager.add_connection(&second_addr).await;
+
+        manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-normal",
+                virtual_id: 9203,
+                provider: "provider-a",
+                stream_url: "http://localhost/live-normal.m3u8",
+                addr: &first_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(ConnectionKind::Normal),
+            })
+            .await;
+        manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-soft",
+                virtual_id: 9204,
+                provider: "provider-a",
+                stream_url: "http://localhost/live-soft.m3u8",
+                addr: &second_addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(ConnectionKind::Normal),
+            })
+            .await;
+
+        let first_admission = manager
+            .connection_admission_for_session_activation(&user.username, user.max_connections, user.soft_connections, "tok-normal")
+            .await;
+        assert_eq!(first_admission.permission, UserConnectionPermission::Allowed);
+        assert_eq!(first_admission.kind, Some(ConnectionKind::Normal));
+
+        manager
+            .update_connection(ActiveUserConnectionParams {
+                uid: 401,
+                meter_uid: 0,
+                username: &user.username,
+                max_connections: user.max_connections,
+                soft_connections: user.soft_connections,
+                connection_kind: ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &first_fingerprint,
+                provider: "provider-a",
+                stream_channel: &test_adaptive_channel(9203),
+                user_agent: Cow::Borrowed("ua"),
+                session_token: Some("tok-normal"),
+            })
+            .await
+            .expect("reserved normal session should bind");
+
+        let second_admission = manager
+            .connection_admission_for_session_activation(&user.username, user.max_connections, user.soft_connections, "tok-soft")
+            .await;
+        assert_eq!(second_admission.permission, UserConnectionPermission::Allowed);
+        assert_eq!(second_admission.kind, Some(ConnectionKind::Soft));
+
+        manager
+            .update_connection(ActiveUserConnectionParams {
+                uid: 402,
+                meter_uid: 0,
+                username: &user.username,
+                max_connections: user.max_connections,
+                soft_connections: user.soft_connections,
+                connection_kind: ConnectionKind::Soft,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &second_fingerprint,
+                provider: "provider-a",
+                stream_channel: &test_adaptive_channel(9204),
+                user_agent: Cow::Borrowed("ua"),
+                session_token: Some("tok-soft"),
+            })
+            .await
+            .expect("reserved soft session should bind");
+
+        let connections = manager.connections.read().await;
+        let connection_data = connections.by_key.get(&user.username).expect("user connection data");
+        assert_eq!(connection_data.connections, 2);
+        assert_eq!(connection_data.counts.normal, 1);
+        assert_eq!(connection_data.counts.soft, 1);
+        assert_eq!(connection_data.streams.len(), 2);
+        assert_eq!(
+            connection_data.stream_kinds.get(&401),
+            Some(&ConnectionKind::Normal),
+            "binding a reserved normal session must not increment counts twice"
+        );
+        assert_eq!(
+            connection_data.stream_kinds.get(&402),
+            Some(&ConnectionKind::Soft),
+            "binding a reserved soft session must keep the soft classification"
+        );
+    }
+
+    #[tokio::test]
+    async fn release_unbound_session_reservation_frees_reserved_slot() {
+        let config = Config::default();
+        let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveUserManager::new(&config, &geoip, &event_manager);
+
+        let mut user = ProxyUserCredentials::default();
+        user.username = String::from("user-release-reservation");
+        user.max_connections = 1;
+
+        let addr: SocketAddr = "127.0.0.1:55184".parse().unwrap();
+        manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-release",
+                virtual_id: 9205,
+                provider: "provider-a",
+                stream_url: "http://localhost/live-release.m3u8",
+                addr: &addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(ConnectionKind::Normal),
+            })
+            .await;
+
+        let admission = manager
+            .connection_admission_for_session_activation(&user.username, user.max_connections, 0, "tok-release")
+            .await;
+        assert_eq!(admission.permission, UserConnectionPermission::Allowed);
+
+        manager
+            .release_unbound_session_reservation(&user.username, "tok-release", false)
+            .await;
+
+        let connections = manager.connections.read().await;
+        let connection_data = connections.by_key.get(&user.username).expect("user connection data");
+        assert_eq!(connection_data.connections, 0);
+        assert_eq!(connection_data.counts.normal, 0);
+        assert_eq!(connection_data.streams.len(), 0);
+        assert!(
+            connection_data
+                .sessions
+                .iter()
+                .find(|session| session.token == "tok-release")
+                .is_some_and(|session| !session.counted)
+        );
     }
 }
 

--- a/backend/src/api/model/active_user_manager.rs
+++ b/backend/src/api/model/active_user_manager.rs
@@ -1492,11 +1492,10 @@ impl ActiveUserManager {
         }
 
         for stream in &mut connection_data.streams {
-            if stream.session_token.as_deref() == Some(token) || stream.addr == *addr {
-                stream.ts = now;
-                if stream.session_token.as_deref() == Some(token) {
-                    stream.addr = *addr;
-                }
+            if stream.session_token.as_deref() == Some(token) {
+                // Only update the addr to keep it current; do NOT reset stream.ts,
+                // which represents the session start time shown as "Duration" in the dashboard.
+                stream.addr = *addr;
             }
         }
     }
@@ -3475,6 +3474,79 @@ mod tests {
         let connection_data = connections.by_key.get("user1").expect("user should still exist");
         assert!(registration.ts > previous_ts);
         assert!(connection_data.sessions[0].ts >= registration.ts);
+    }
+
+    #[tokio::test]
+    async fn touch_http_activity_does_not_reset_stream_started_at_ts() {
+        let config = Config::default();
+        let geoip = Arc::new(ArcSwapOption::<GeoIp>::default());
+        let event_manager = Arc::new(EventManager::new());
+        let manager = ActiveUserManager::new(&config, &geoip, &event_manager);
+
+        let addr1: SocketAddr = "127.0.0.1:55030".parse().unwrap();
+        let addr2: SocketAddr = "127.0.0.1:55031".parse().unwrap();
+        let fingerprint = Fingerprint::new("fp".to_string(), "127.0.0.1".to_string(), addr1);
+        let mut user = ProxyUserCredentials::default();
+        user.username = "user-touch-ts".to_string();
+
+        manager.add_connection(&addr1).await;
+        manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-hls-ts",
+                virtual_id: 7777,
+                provider: "provider-a",
+                stream_url: "http://localhost/live.m3u8",
+                addr: &addr1,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(ConnectionKind::Normal),
+            })
+            .await;
+
+        // Simulate first HLS segment: creates the stream entry with ts = now
+        manager
+            .update_connection(ActiveUserConnectionParams {
+                uid: 601,
+                meter_uid: 701,
+                username: "user-touch-ts",
+                max_connections: 0,
+                soft_connections: 0,
+                connection_kind: ConnectionKind::Normal,
+                priority: 0,
+                soft_priority: 0,
+                fingerprint: &fingerprint,
+                provider: "provider-a",
+                stream_channel: &test_adaptive_channel(7777),
+                user_agent: Cow::Borrowed("player/1.0"),
+                session_token: Some("tok-hls-ts"),
+            })
+            .await
+            .expect("stream should be created");
+
+        // Record the original stream start timestamp
+        let original_ts = {
+            let connections = manager.connections.read().await;
+            connections
+                .by_key
+                .get("user-touch-ts")
+                .and_then(|data| data.streams.iter().find(|s| s.session_token.as_deref() == Some("tok-hls-ts")))
+                .map(|s| s.ts)
+                .expect("stream should exist")
+        };
+
+        // Simulate manifest re-fetch (touch_http_activity called with a new addr)
+        manager.touch_http_activity("user-touch-ts", "tok-hls-ts", &addr2).await;
+
+        // stream.ts must NOT have been reset — it represents session start time shown as Duration
+        let connections = manager.connections.read().await;
+        let stream = connections
+            .by_key
+            .get("user-touch-ts")
+            .and_then(|data| data.streams.iter().find(|s| s.session_token.as_deref() == Some("tok-hls-ts")))
+            .expect("stream should still exist");
+        assert_eq!(stream.ts, original_ts, "touch_http_activity must not reset the stream start timestamp");
+        // addr should be updated to reflect the latest manifest request
+        assert_eq!(stream.addr, addr2, "touch_http_activity should update the stream addr");
     }
 
     #[tokio::test]

--- a/backend/src/api/model/active_user_manager.rs
+++ b/backend/src/api/model/active_user_manager.rs
@@ -9,10 +9,13 @@ use arc_swap::ArcSwapOption;
 use jsonwebtoken::get_current_timestamp;
 use log::{debug, info};
 use shared::{
-    model::{ActiveUserConnectionChange, StreamChannel, StreamInfo, StreamTechnicalInfo, UserConnectionPermission, VirtualId},
+    model::{
+        ActiveUserConnectionChange, PlaylistItemType, StreamChannel, StreamInfo, StreamTechnicalInfo,
+        UserConnectionPermission, VirtualId,
+    },
     utils::{
-        current_time_secs, default_grace_period_millis, default_grace_period_timeout_secs,
-        default_hls_session_ttl_secs, sanitize_sensitive_info, strip_port, Internable,
+        current_time_secs, default_grace_period_millis, default_grace_period_timeout_secs, default_hls_session_ttl_secs,
+        extract_extension_from_url, sanitize_sensitive_info, strip_port, Internable, DASH_EXT, HLS_EXT,
     },
 };
 use std::{
@@ -234,9 +237,30 @@ impl UserConnectionData {
     }
 }
 
+fn create_socket_reentry_guard_key(username: &str, client_ip: &str, virtual_id: VirtualId) -> String {
+    shared::concat_string!(username, "|", client_ip, "|", &virtual_id.to_string())
+}
+
+fn is_stable_session_stream(stream: &StreamInfo) -> bool {
+    stream.channel.item_type == PlaylistItemType::Catchup
+        || stream.channel.item_type.is_live_adaptive()
+        || matches!(
+            extract_extension_from_url(stream.channel.url.as_ref()).as_deref(),
+            Some(ext) if ext == HLS_EXT || ext == DASH_EXT
+        )
+}
+
+#[derive(Clone, Copy, Debug)]
+struct RecentWinnerProtection {
+    protected_addr: SocketAddr,
+    expires_at: u64,
+}
+
 #[derive(Debug, Default)]
 struct UserConnections {
     kicked: HashMap<String, (u64, VirtualId)>,
+    recently_evicted_sessions: HashMap<String, RecentWinnerProtection>,
+    recent_socket_reentry_guards: HashMap<String, RecentWinnerProtection>,
     by_key: HashMap<String, UserConnectionData>,
     key_by_addr: HashMap<SocketAddr, SocketRegistration>,
 }
@@ -1583,6 +1607,30 @@ impl ActiveUserManager {
         matches!(connections.kicked.get(username), Some((expires_at, vid)) if *vid == virtual_id && *expires_at > now)
     }
 
+    pub async fn recently_evicted_session_protected_addr(&self, session_token: &str) -> Option<SocketAddr> {
+        let connections = self.connections.read().await;
+        let now = current_time_secs();
+        connections
+            .recently_evicted_sessions
+            .get(session_token)
+            .and_then(|protection| (protection.expires_at > now).then_some(protection.protected_addr))
+    }
+
+    pub async fn recent_socket_reentry_protected_addr(
+        &self,
+        username: &str,
+        client_ip: &str,
+        virtual_id: VirtualId,
+    ) -> Option<SocketAddr> {
+        let connections = self.connections.read().await;
+        let now = current_time_secs();
+        let key = create_socket_reentry_guard_key(username, client_ip, virtual_id);
+        connections
+            .recent_socket_reentry_guards
+            .get(&key)
+            .and_then(|protection| (protection.expires_at > now).then_some(protection.protected_addr))
+    }
+
     pub async fn block_user_for_stream(&self, addr: &SocketAddr, virtual_id: VirtualId, blocked_secs: u64) {
         let block_for_secs = blocked_secs.clamp(0, 86_400); // max 1 day;
         if block_for_secs > 0 {
@@ -1598,6 +1646,71 @@ impl ActiveUserManager {
                 let expires_at = now + block_for_secs;
                 connections.kicked.insert(username, (expires_at, virtual_id));
             }
+        }
+    }
+
+    pub async fn mark_recent_eviction_guard_for_addr(
+        &self,
+        addr: &SocketAddr,
+        protected_addr: SocketAddr,
+        ttl_secs: u64,
+    ) {
+        if ttl_secs == 0 {
+            return;
+        }
+
+        let mut connections = self.connections.write().await;
+        let now = current_time_secs();
+        connections
+            .recently_evicted_sessions
+            .retain(|_, protection| protection.expires_at > now);
+        connections
+            .recent_socket_reentry_guards
+            .retain(|_, protection| protection.expires_at > now);
+
+        let Some(username) = connections
+            .key_by_addr
+            .get(addr)
+            .map(|registration| registration.username.clone())
+            .filter(|username| !username.is_empty())
+        else {
+            return;
+        };
+
+        let Some(connection_data) = connections.by_key.get(&username) else {
+            return;
+        };
+
+        let protection = RecentWinnerProtection {
+            protected_addr,
+            expires_at: now + ttl_secs,
+        };
+        let mut session_tokens = Vec::new();
+        let mut socket_guard_keys = Vec::new();
+
+        for stream in connection_data.streams.iter().filter(|stream| stream.addr == *addr) {
+            if is_stable_session_stream(stream) {
+                if let Some(session_token) = stream.session_token.clone() {
+                    session_tokens.push(session_token);
+                }
+            } else {
+                socket_guard_keys.push(create_socket_reentry_guard_key(
+                    &username,
+                    &stream.client_ip,
+                    stream.channel.virtual_id,
+                ));
+            }
+        }
+
+        for session_token in session_tokens {
+            connections
+                .recently_evicted_sessions
+                .insert(session_token, protection);
+        }
+        for key in socket_guard_keys {
+            connections
+                .recent_socket_reentry_guards
+                .insert(key, protection);
         }
     }
 
@@ -1813,6 +1926,12 @@ impl ActiveUserManager {
             {
                 if let Ok(mut user_connections) = self.connections.try_write() {
                     user_connections.kicked.retain(|_, (expires_at, _)| *expires_at > now);
+                    user_connections
+                        .recently_evicted_sessions
+                        .retain(|_, protection| protection.expires_at > now);
+                    user_connections
+                        .recent_socket_reentry_guards
+                        .retain(|_, protection| protection.expires_at > now);
                     for connection_data in user_connections.by_key.values_mut() {
                         Self::release_expired_session_reservations(connection_data, now);
                         connection_data.sessions.retain(|s| now.saturating_sub(s.ts) < USER_CON_TTL);

--- a/backend/src/api/model/admission_strategy.rs
+++ b/backend/src/api/model/admission_strategy.rs
@@ -90,6 +90,8 @@ pub(in crate::api) fn evaluate_strategy(
         AdmissionStrategy::EvictUserSameIpLatest => {
             evaluate_evict_same_ip(ctx, candidates, EvictionOrder::Latest)
         }
+        AdmissionStrategy::EvictUserOldest => evaluate_evict_user(candidates, EvictionOrder::Oldest),
+        AdmissionStrategy::EvictUserLatest => evaluate_evict_user(candidates, EvictionOrder::Latest),
         AdmissionStrategy::GraceInstantStream => AdmissionDecision::Grace(GraceMode::Instant),
         AdmissionStrategy::GraceHoldStream => AdmissionDecision::Grace(GraceMode::Hold),
     }
@@ -106,22 +108,10 @@ fn evaluate_evict_same_ip(
     candidates: &[EvictionCandidate],
     order: EvictionOrder,
 ) -> AdmissionDecision {
-    let mut selected: Option<&EvictionCandidate> = None;
-    for candidate in candidates {
-        if candidate.client_ip != ctx.client_ip {
-            continue;
-        }
-        let should_replace = match selected {
-            None => true,
-            Some(current) => match order {
-                EvictionOrder::Oldest => candidate.ts < current.ts,
-                EvictionOrder::Latest => candidate.ts > current.ts,
-            },
-        };
-        if should_replace {
-            selected = Some(candidate);
-        }
-    }
+    let selected = select_candidate(
+        candidates.iter().filter(|candidate| candidate.client_ip == ctx.client_ip),
+        order,
+    );
 
     if selected.is_none() {
         debug!(
@@ -141,6 +131,35 @@ fn evaluate_evict_same_ip(
         }),
         None => AdmissionDecision::NoMatch,
     }
+}
+
+fn evaluate_evict_user(candidates: &[EvictionCandidate], order: EvictionOrder) -> AdmissionDecision {
+    match select_candidate(candidates.iter(), order) {
+        Some(candidate) => AdmissionDecision::Evict(EvictionTarget {
+            addr: candidate.addr,
+        }),
+        None => AdmissionDecision::NoMatch,
+    }
+}
+
+fn select_candidate<'a>(
+    candidates: impl Iterator<Item = &'a EvictionCandidate>,
+    order: EvictionOrder,
+) -> Option<&'a EvictionCandidate> {
+    let mut selected: Option<&EvictionCandidate> = None;
+    for candidate in candidates {
+        let should_replace = match selected {
+            None => true,
+            Some(current) => match order {
+                EvictionOrder::Oldest => candidate.ts < current.ts,
+                EvictionOrder::Latest => candidate.ts > current.ts,
+            },
+        };
+        if should_replace {
+            selected = Some(candidate);
+        }
+    }
+    selected
 }
 
 #[derive(Debug, Clone)]
@@ -243,6 +262,44 @@ mod tests {
         let result = evaluate_admission_strategies(&ctx, &candidates);
         match result {
             AdmissionDecision::Evict(target) => assert_eq!(target.addr, addr(1001)),
+            other => panic!("Expected Evict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evict_oldest_user_regardless_of_ip() {
+        let ctx = StrategyContext {
+            username: "user1",
+            client_ip: "1.1.1.1",
+            strategies: &[AdmissionStrategy::EvictUserOldest],
+        };
+        let candidates = vec![
+            candidate(1000, "2.2.2.2", 300),
+            candidate(1001, "1.1.1.1", 200),
+            candidate(1002, "3.3.3.3", 100),
+        ];
+        let result = evaluate_admission_strategies(&ctx, &candidates);
+        match result {
+            AdmissionDecision::Evict(target) => assert_eq!(target.addr, addr(1002)),
+            other => panic!("Expected Evict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evict_latest_user_regardless_of_ip() {
+        let ctx = StrategyContext {
+            username: "user1",
+            client_ip: "1.1.1.1",
+            strategies: &[AdmissionStrategy::EvictUserLatest],
+        };
+        let candidates = vec![
+            candidate(1000, "2.2.2.2", 300),
+            candidate(1001, "1.1.1.1", 200),
+            candidate(1002, "3.3.3.3", 100),
+        ];
+        let result = evaluate_admission_strategies(&ctx, &candidates);
+        match result {
+            AdmissionDecision::Evict(target) => assert_eq!(target.addr, addr(1000)),
             other => panic!("Expected Evict, got {other:?}"),
         }
     }

--- a/backend/src/api/model/admission_strategy.rs
+++ b/backend/src/api/model/admission_strategy.rs
@@ -1,6 +1,6 @@
-use crate::model::AdmissionStrategy;
 use log::debug;
 use std::net::SocketAddr;
+use shared::model::AdmissionStrategy;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AdmissionDecision {

--- a/backend/src/api/model/app_state.rs
+++ b/backend/src/api/model/app_state.rs
@@ -529,6 +529,18 @@ impl AppState {
             .await
     }
 
+    pub(crate) async fn get_connection_admission_for_session_activation(
+        &self,
+        username: &str,
+        max_connections: u32,
+        soft_connections: u16,
+        session_token: &str,
+    ) -> ConnectionAdmission {
+        self.active_users
+            .connection_admission_for_session_activation(username, max_connections, soft_connections, session_token)
+            .await
+    }
+
     pub async fn get_connection_permission(
         &self,
         username: &str,

--- a/backend/src/api/model/connection_manager.rs
+++ b/backend/src/api/model/connection_manager.rs
@@ -17,13 +17,14 @@ use shared::{
 use std::{
     borrow::Cow,
     cmp::Reverse,
-    collections::{BinaryHeap, HashMap},
+    collections::{BinaryHeap, HashMap, VecDeque},
     net::SocketAddr,
     str::FromStr,
     sync::{
         atomic::{AtomicU32, Ordering},
-        Arc,
+        Arc, Mutex, MutexGuard,
     },
+    thread,
     time::Duration,
 };
 use tokio::sync::{mpsc, Notify};
@@ -34,13 +35,171 @@ const CLEANUP_QUEUE_CAPACITY: usize = 4096;
 pub(crate) const PROVIDER_END_NOT_SET: u8 = 0;
 pub(crate) const PROVIDER_END_CLOSED: u8 = 1; // Provider EOF
 pub(crate) const PROVIDER_END_ERROR: u8 = 2; // Provider Err
-// Maximum number of adaptive HTTP activity updates waiting to refresh socket expiry state.
-const SOCKET_ACTIVITY_QUEUE_CAPACITY: usize = 4096;
 // Rebuild the expiry heap when it grows beyond this multiple of the live index size.
 const SOCKET_EXPIRY_QUEUE_REBUILD_FACTOR: usize = 2;
 // Avoid rebuilding the expiry heap unless it contains at least this many stale entries.
 const SOCKET_EXPIRY_QUEUE_REBUILD_MIN_STALE: usize = 256;
 fn notify_capacity(capacity_notify: &Notify) { capacity_notify.notify_waiters(); }
+
+struct BackpressureState<T> {
+    overflow: VecDeque<T>,
+    draining: bool,
+}
+
+struct BackpressureSender<T> {
+    tx: mpsc::Sender<T>,
+    state: Arc<Mutex<BackpressureState<T>>>,
+    queue_name: &'static str,
+}
+
+impl<T> BackpressureSender<T>
+where
+    T: Send + 'static,
+{
+    fn new(tx: mpsc::Sender<T>, queue_name: &'static str) -> Self {
+        Self {
+            tx,
+            state: Arc::new(Mutex::new(BackpressureState {
+                overflow: VecDeque::new(),
+                draining: false,
+            })),
+            queue_name,
+        }
+    }
+
+    fn enqueue(&self, event: T) {
+        let runtime = tokio::runtime::Handle::try_current().ok();
+        {
+            let mut state = lock_backpressure_state(self.state.as_ref());
+            if state.draining {
+                state.overflow.push_back(event);
+                return;
+            }
+
+            match self.tx.try_send(event) {
+                Ok(()) => return,
+                Err(tokio::sync::mpsc::error::TrySendError::Full(event)) => {
+                    state.draining = true;
+                    state.overflow.push_back(event);
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_event)) => {
+                    debug!("{} channel closed, dropping event", self.queue_name);
+                    return;
+                }
+            }
+        }
+
+        let tx = self.tx.clone();
+        let state = Arc::clone(&self.state);
+        let queue_name = self.queue_name;
+        if let Some(handle) = runtime {
+            handle.spawn(async move { Self::drain_async(&tx, &state, queue_name).await; });
+        } else {
+            thread::spawn(move || Self::drain_blocking(&tx, &state, queue_name));
+        }
+    }
+
+    async fn drain_async(
+        tx: &mpsc::Sender<T>,
+        state: &Arc<Mutex<BackpressureState<T>>>,
+        queue_name: &'static str,
+    ) {
+        loop {
+            let Some(event) = Self::next_event(state) else {
+                break;
+            };
+            if tx.send(event).await.is_err() {
+                debug!("{queue_name} channel closed while draining backpressure");
+                Self::clear_and_stop(state);
+                break;
+            }
+        }
+    }
+
+    fn drain_blocking(
+        tx: &mpsc::Sender<T>,
+        state: &Arc<Mutex<BackpressureState<T>>>,
+        queue_name: &'static str,
+    ) {
+        loop {
+            let Some(event) = Self::next_event(state) else {
+                break;
+            };
+            if tx.blocking_send(event).is_err() {
+                warn!("{queue_name} channel closed while draining backpressure");
+                Self::clear_and_stop(state);
+                break;
+            }
+        }
+    }
+
+    fn next_event(state: &Arc<Mutex<BackpressureState<T>>>) -> Option<T> {
+        let mut state = lock_backpressure_state(state.as_ref());
+        if let Some(event) = state.overflow.pop_front() {
+            return Some(event);
+        }
+        state.draining = false;
+        None
+    }
+
+    fn clear_and_stop(state: &Arc<Mutex<BackpressureState<T>>>) {
+        let mut state = lock_backpressure_state(state.as_ref());
+        state.overflow.clear();
+        state.draining = false;
+    }
+}
+
+fn lock_backpressure_state<T>(state: &Mutex<BackpressureState<T>>) -> MutexGuard<'_, BackpressureState<T>> {
+    match state.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            warn!("Backpressure queue state was poisoned, continuing with recovered state");
+            poisoned.into_inner()
+        }
+    }
+}
+
+#[derive(Clone)]
+struct SocketActivityTracker {
+    pending: Arc<Mutex<HashMap<SocketAddr, SocketActivityEvent>>>,
+    notify: Arc<Notify>,
+}
+
+impl SocketActivityTracker {
+    fn new() -> Self {
+        Self {
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    fn track(&self, event: SocketActivityEvent) {
+        let key = event.addr();
+        let mut pending = lock_socket_activity_pending(self.pending.as_ref());
+        pending.insert(key, event);
+        drop(pending);
+        self.notify.notify_one();
+    }
+
+    fn drain(&self) -> Vec<SocketActivityEvent> {
+        let mut pending = lock_socket_activity_pending(self.pending.as_ref());
+        pending.drain().map(|(_, event)| event).collect()
+    }
+
+    async fn notified(&self) { self.notify.notified().await; }
+}
+
+fn lock_socket_activity_pending(
+    pending: &Mutex<HashMap<SocketAddr, SocketActivityEvent>>,
+) -> MutexGuard<'_, HashMap<SocketAddr, SocketActivityEvent>> {
+    match pending.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            warn!("Socket activity state was poisoned, continuing with recovered state");
+            poisoned.into_inner()
+        }
+    }
+}
 
 struct CleanupWorkerDeps {
     user_manager: Arc<ActiveUserManager>,
@@ -307,8 +466,22 @@ struct SocketExpiryEntry {
     addr: SocketAddr,
 }
 
-#[derive(Clone, Copy, Debug)]
-enum SocketActivityEvent { Track(SocketAddr) }
+#[derive(Clone, Debug)]
+enum SocketActivityEvent {
+    HttpActivity {
+        username: String,
+        token: String,
+        addr: SocketAddr,
+    },
+}
+
+impl SocketActivityEvent {
+    fn addr(&self) -> SocketAddr {
+        match self {
+            Self::HttpActivity { addr, .. } => *addr,
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum CloseConnectionSignal {
@@ -321,8 +494,8 @@ pub struct ConnectionManager {
     pub shared_stream_manager: Arc<SharedStreamManager>,
     event_manager: Arc<EventManager>,
     close_socket_signal_tx: tokio::sync::broadcast::Sender<CloseConnectionSignal>,
-    cleanup_tx: mpsc::Sender<CleanupEvent>,
-    socket_activity_tx: mpsc::Sender<SocketActivityEvent>,
+    cleanup_sender: BackpressureSender<CleanupEvent>,
+    socket_activity_tracker: SocketActivityTracker,
     capacity_notify: Arc<Notify>,
     stream_uid_counter: AtomicU32,
     history_writer: Arc<ArcSwapOption<StreamHistoryWriter>>,
@@ -356,8 +529,8 @@ impl ConnectionManager {
         let (cleanup_tx, cleanup_rx) = mpsc::channel(CLEANUP_QUEUE_CAPACITY);
         user_manager.set_cleanup_sender(cleanup_tx.clone());
         user_manager.set_provider_manager(Arc::clone(provider_manager));
-        let (socket_activity_tx, socket_activity_rx) = mpsc::channel(SOCKET_ACTIVITY_QUEUE_CAPACITY);
         let socket_cleanup_tx = cleanup_tx.clone();
+        let socket_activity_tracker = SocketActivityTracker::new();
         let capacity_notify = Arc::new(Notify::new());
         let mgr = Self {
             user_manager: Arc::clone(user_manager),
@@ -365,8 +538,8 @@ impl ConnectionManager {
             shared_stream_manager: Arc::clone(shared_stream_manager),
             event_manager: Arc::clone(event_manager),
             close_socket_signal_tx,
-            cleanup_tx,
-            socket_activity_tx,
+            cleanup_sender: BackpressureSender::new(cleanup_tx, "cleanup"),
+            socket_activity_tracker: socket_activity_tracker.clone(),
             capacity_notify: Arc::clone(&capacity_notify),
             stream_uid_counter: AtomicU32::new(1),
             history_writer: Arc::clone(&history_writer),
@@ -382,7 +555,7 @@ impl ConnectionManager {
             history_writer,
         );
         Self::spawn_socket_activity_worker(
-            socket_activity_rx,
+            socket_activity_tracker,
             Arc::clone(user_manager),
             socket_cleanup_tx,
         );
@@ -402,7 +575,7 @@ impl ConnectionManager {
     }
 
     fn spawn_socket_activity_worker(
-        mut rx: mpsc::Receiver<SocketActivityEvent>,
+        activity_tracker: SocketActivityTracker,
         user_manager: Arc<ActiveUserManager>,
         cleanup_tx: mpsc::Sender<CleanupEvent>,
     ) {
@@ -411,6 +584,8 @@ impl ConnectionManager {
             let mut expiry_index: HashMap<SocketAddr, u64> = HashMap::new();
 
             loop {
+                Self::drain_pending_socket_activity(&activity_tracker, &mut expiry_queue, &mut expiry_index, &user_manager).await;
+
                 let next_expiry = expiry_queue.peek().map(|entry| entry.0.expires_at);
                 if let Some(expires_at) = next_expiry {
                     let now = shared::utils::current_time_secs();
@@ -427,22 +602,26 @@ impl ConnectionManager {
                     }
 
                     tokio::select! {
-                        maybe_event = rx.recv() => {
-                            let Some(event) = maybe_event else {
-                                break;
-                            };
-                            Self::handle_socket_activity_event(event, &mut expiry_queue, &mut expiry_index, &user_manager).await;
-                        }
+                        biased;
+                        () = activity_tracker.notified() => {}
                         () = tokio::time::sleep(Duration::from_secs(expires_at.saturating_sub(now))) => {}
                     }
                 } else {
-                    let Some(event) = rx.recv().await else {
-                        break;
-                    };
-                    Self::handle_socket_activity_event(event, &mut expiry_queue, &mut expiry_index, &user_manager).await;
+                    activity_tracker.notified().await;
                 }
             }
         });
+    }
+
+    async fn drain_pending_socket_activity(
+        activity_tracker: &SocketActivityTracker,
+        expiry_queue: &mut BinaryHeap<Reverse<SocketExpiryEntry>>,
+        expiry_index: &mut HashMap<SocketAddr, u64>,
+        user_manager: &Arc<ActiveUserManager>,
+    ) {
+        for event in activity_tracker.drain() {
+            Self::handle_socket_activity_event(event, expiry_queue, expiry_index, user_manager).await;
+        }
     }
 
     async fn handle_socket_activity_event(
@@ -451,7 +630,9 @@ impl ConnectionManager {
         expiry_index: &mut HashMap<SocketAddr, u64>,
         user_manager: &Arc<ActiveUserManager>,
     ) {
-        let SocketActivityEvent::Track(addr) = event;
+        let SocketActivityEvent::HttpActivity { username, token, addr } = event;
+
+        user_manager.touch_http_activity(&username, &token, &addr).await;
 
         if let Some(expires_at) = user_manager.socket_expiry_deadline(&addr).await {
             let current = expiry_index.insert(addr, expires_at);
@@ -608,17 +789,7 @@ impl ConnectionManager {
         });
     }
 
-    pub(crate) fn send_cleanup(&self, event: CleanupEvent) {
-        match self.cleanup_tx.try_send(event) {
-            Ok(()) => {}
-            Err(tokio::sync::mpsc::error::TrySendError::Full(_event)) => {
-                warn!("Cleanup queue full, dropping event");
-            }
-            Err(tokio::sync::mpsc::error::TrySendError::Closed(_event)) => {
-                debug!("Cleanup channel closed, dropping cleanup event");
-            }
-        }
-    }
+    pub(crate) fn send_cleanup(&self, event: CleanupEvent) { self.cleanup_sender.enqueue(event); }
 
     pub fn get_close_connection_channel(&self) -> tokio::sync::broadcast::Receiver<CloseConnectionSignal> { self.close_socket_signal_tx.subscribe() }
 
@@ -772,15 +943,14 @@ impl ConnectionManager {
 
     pub async fn add_connection(&self, addr: &SocketAddr) { self.user_manager.add_connection(addr).await; }
 
-    async fn track_socket_activity(&self, addr: &SocketAddr) {
-        if self.socket_activity_tx.send(SocketActivityEvent::Track(*addr)).await.is_err() {
-            debug!("Socket activity channel closed, dropping socket activity event");
-        }
-    }
-
-    pub async fn touch_http_activity(&self, username: &str, token: &str, addr: &SocketAddr) {
-        self.user_manager.touch_http_activity(username, token, addr).await;
-        self.track_socket_activity(addr).await;
+    pub fn touch_http_activity(&self, username: &str, token: &str, addr: &SocketAddr) {
+        self.socket_activity_tracker.track(
+            SocketActivityEvent::HttpActivity {
+                username: username.to_string(),
+                token: token.to_string(),
+                addr: *addr,
+            },
+        );
     }
 
     pub async fn update_connection(&self, update: ConnectionParams<'_>) {
@@ -920,16 +1090,17 @@ fn resolve_disconnect_failure_stage(info: &StreamInfo, reason: &DisconnectReason
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::model::{ActiveProviderManager, ActiveUserManager, EventManager, SharedStreamManager};
-    use crate::model::{AppConfig, Config, ConfigInput, MediaToolCapabilities, SourcesConfig};
+    use crate::api::model::{ActiveProviderManager, ActiveUserManager, CreateUserSessionParams, EventManager, SharedStreamManager};
+    use crate::model::{AppConfig, Config, ConfigInput, MediaToolCapabilities, ProxyUserCredentials, SourcesConfig};
     use crate::utils::{FileLockManager, GeoIp};
     use arc_swap::{ArcSwap, ArcSwapOption};
-    use shared::model::{ConfigPaths, InputFetchMethod, InputType};
+    use shared::model::{ConfigPaths, InputFetchMethod, InputType, ProxyType, UserConnectionPermission};
     use shared::model::{PlaylistItemType, StreamChannel, StreamInfo, XtreamCluster};
     use shared::utils::Internable;
     use std::collections::HashMap;
     use std::net::SocketAddr;
     use std::sync::Arc;
+    use tokio::sync::mpsc;
 
     fn make_stream_info(provider: &str, title: &str) -> StreamInfo {
         let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap_or_else(|_| unreachable!());
@@ -1013,6 +1184,108 @@ mod tests {
             &event_manager,
             None,
         ))
+    }
+
+    fn create_test_proxy_user(username: &str) -> ProxyUserCredentials {
+        let mut user = ProxyUserCredentials::default();
+        user.username = username.to_string();
+        user.password = "password".to_string();
+        user.proxy = ProxyType::Reverse(None);
+        user.max_connections = 1;
+        user
+    }
+
+    #[tokio::test]
+    async fn enqueue_with_backpressure_delivers_events_after_queue_full() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let sender = BackpressureSender::new(tx.clone(), "test");
+        assert!(tx.send(1_u8).await.is_ok());
+
+        sender.enqueue(2_u8);
+        sender.enqueue(3_u8);
+
+        assert_eq!(rx.recv().await, Some(1));
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv()).await.ok().flatten(),
+            Some(2)
+        );
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv()).await.ok().flatten(),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn socket_activity_tracker_coalesces_updates_per_socket() {
+        let tracker = SocketActivityTracker::new();
+        let addr_one: SocketAddr = "127.0.0.1:3234".parse().unwrap_or_else(|_| unreachable!());
+        let addr_two: SocketAddr = "127.0.0.1:3235".parse().unwrap_or_else(|_| unreachable!());
+
+        tracker.track(SocketActivityEvent::HttpActivity {
+            username: String::from("user1"),
+            token: String::from("tok-old"),
+            addr: addr_one,
+        });
+        tracker.track(SocketActivityEvent::HttpActivity {
+            username: String::from("user1"),
+            token: String::from("tok-new"),
+            addr: addr_one,
+        });
+        tracker.track(SocketActivityEvent::HttpActivity {
+            username: String::from("user2"),
+            token: String::from("tok-two"),
+            addr: addr_two,
+        });
+
+        let pending = tracker.drain();
+        assert_eq!(pending.len(), 2);
+        assert!(pending.iter().any(|event| matches!(
+            event,
+            SocketActivityEvent::HttpActivity { addr, token, .. } if *addr == addr_one && token == "tok-new"
+        )));
+        assert!(pending.iter().any(|event| matches!(
+            event,
+            SocketActivityEvent::HttpActivity { addr, token, .. } if *addr == addr_two && token == "tok-two"
+        )));
+    }
+
+    #[tokio::test]
+    async fn touch_http_activity_is_processed_by_socket_activity_worker() {
+        let manager = create_test_connection_manager();
+        let addr: SocketAddr = "127.0.0.1:3234".parse().unwrap_or_else(|_| unreachable!());
+        let user = create_test_proxy_user("user1");
+
+        manager.add_connection(&addr).await;
+        let _ = manager
+            .user_manager
+            .create_user_session(CreateUserSessionParams {
+                user: &user,
+                session_token: "tok-touch",
+                virtual_id: 1,
+                provider: "provider_1",
+                stream_url: "http://provider-1.example/live.ts",
+                addr: &addr,
+                connection_permission: UserConnectionPermission::Allowed,
+                connection_kind: Some(crate::api::model::ConnectionKind::Normal),
+            })
+            .await;
+
+        manager.touch_http_activity(&user.username, "tok-touch", &addr);
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), async {
+                loop {
+                    if manager.user_manager.socket_expiry_deadline(&addr).await.is_some()
+                        && manager.user_manager.get_username_for_addr(&addr).await.as_deref() == Some(user.username.as_str())
+                    {
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .is_ok()
+        );
     }
 
     #[tokio::test]

--- a/backend/src/api/model/connection_manager.rs
+++ b/backend/src/api/model/connection_manager.rs
@@ -690,10 +690,9 @@ impl ConnectionManager {
                     Self::maybe_rebuild_socket_expiry_queue(expiry_queue, expiry_index);
                     continue;
                 }
-            } else {
-                expiry_index.remove(&addr);
-                continue;
             }
+
+            // Fallthrough to release connection if `None` or `< now`
 
             expiry_index.remove(&addr);
             if cleanup_tx.send(CleanupEvent::ReleaseConnection { addr }).await.is_err() {

--- a/backend/src/api/model/connection_manager.rs
+++ b/backend/src/api/model/connection_manager.rs
@@ -486,8 +486,6 @@ struct SocketExpiryEntry {
 #[derive(Clone, Debug)]
 enum SocketActivityEvent {
     HttpActivity {
-        username: String,
-        token: String,
         addr: SocketAddr,
     },
 }
@@ -647,9 +645,7 @@ impl ConnectionManager {
         expiry_index: &mut HashMap<SocketAddr, u64>,
         user_manager: &Arc<ActiveUserManager>,
     ) {
-        let SocketActivityEvent::HttpActivity { username, token, addr } = event;
-
-        user_manager.touch_http_activity(&username, &token, &addr).await;
+        let SocketActivityEvent::HttpActivity { addr } = event;
 
         if let Some(expires_at) = user_manager.socket_expiry_deadline(&addr).await {
             let current = expiry_index.insert(addr, expires_at);
@@ -959,14 +955,9 @@ impl ConnectionManager {
 
     pub async fn add_connection(&self, addr: &SocketAddr) { self.user_manager.add_connection(addr).await; }
 
-    pub fn touch_http_activity(&self, username: &str, token: &str, addr: &SocketAddr) {
-        self.socket_activity_tracker.track(
-            SocketActivityEvent::HttpActivity {
-                username: username.to_string(),
-                token: token.to_string(),
-                addr: *addr,
-            },
-        );
+    pub async fn touch_http_activity(&self, username: &str, token: &str, addr: &SocketAddr) {
+        self.user_manager.touch_http_activity(username, token, addr).await;
+        self.socket_activity_tracker.track(SocketActivityEvent::HttpActivity { addr: *addr });
     }
 
     pub async fn update_connection(&self, update: ConnectionParams<'_>) {
@@ -1238,7 +1229,15 @@ mod tests {
         assert!(tx.send(1_u8).await.is_ok());
 
         sender.enqueue(2_u8);
-        tokio::task::yield_now().await;
+        for _ in 0..50 {
+            let state = super::lock_backpressure_state(sender.state.as_ref());
+            let ready = state.overflow.is_empty() && state.draining;
+            drop(state);
+            if ready {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
         sender.enqueue(3_u8);
         sender.enqueue(4_u8);
 
@@ -1261,31 +1260,19 @@ mod tests {
         let addr_one: SocketAddr = "127.0.0.1:3234".parse().unwrap_or_else(|_| unreachable!());
         let addr_two: SocketAddr = "127.0.0.1:3235".parse().unwrap_or_else(|_| unreachable!());
 
-        tracker.track(SocketActivityEvent::HttpActivity {
-            username: String::from("user1"),
-            token: String::from("tok-old"),
-            addr: addr_one,
-        });
-        tracker.track(SocketActivityEvent::HttpActivity {
-            username: String::from("user1"),
-            token: String::from("tok-new"),
-            addr: addr_one,
-        });
-        tracker.track(SocketActivityEvent::HttpActivity {
-            username: String::from("user2"),
-            token: String::from("tok-two"),
-            addr: addr_two,
-        });
+        tracker.track(SocketActivityEvent::HttpActivity { addr: addr_one });
+        tracker.track(SocketActivityEvent::HttpActivity { addr: addr_one });
+        tracker.track(SocketActivityEvent::HttpActivity { addr: addr_two });
 
         let pending = tracker.drain();
         assert_eq!(pending.len(), 2);
         assert!(pending.iter().any(|event| matches!(
             event,
-            SocketActivityEvent::HttpActivity { addr, token, .. } if *addr == addr_one && token == "tok-new"
+            SocketActivityEvent::HttpActivity { addr } if *addr == addr_one
         )));
         assert!(pending.iter().any(|event| matches!(
             event,
-            SocketActivityEvent::HttpActivity { addr, token, .. } if *addr == addr_two && token == "tok-two"
+            SocketActivityEvent::HttpActivity { addr } if *addr == addr_two
         )));
     }
 
@@ -1310,7 +1297,7 @@ mod tests {
             })
             .await;
 
-        manager.touch_http_activity(&user.username, "tok-touch", &addr);
+        manager.touch_http_activity(&user.username, "tok-touch", &addr).await;
 
         assert!(
             tokio::time::timeout(Duration::from_secs(1), async {

--- a/backend/src/api/model/connection_manager.rs
+++ b/backend/src/api/model/connection_manager.rs
@@ -1235,7 +1235,7 @@ mod tests {
     #[tokio::test]
     async fn enqueue_with_backpressure_bounds_overflow_buffer() {
         let (tx, mut rx) = mpsc::channel(1);
-        let sender = BackpressureSender::new(tx.clone(), "test", 1);
+        let sender = BackpressureSender::new(tx.clone(), "test", 2);
         assert!(tx.send(1_u8).await.is_ok());
 
         sender.enqueue(2_u8);
@@ -1251,10 +1251,8 @@ mod tests {
             tokio::time::timeout(Duration::from_secs(1), rx.recv()).await.ok().flatten(),
             Some(3)
         );
-        assert_eq!(
-            tokio::time::timeout(Duration::from_millis(100), rx.recv()).await,
-            Err(tokio::time::error::Elapsed(()))
-        );
+        let result = tokio::time::timeout(Duration::from_millis(100), rx.recv()).await;
+        assert!(result.is_err());
     }
 
     #[test]

--- a/backend/src/api/model/connection_manager.rs
+++ b/backend/src/api/model/connection_manager.rs
@@ -1235,10 +1235,11 @@ mod tests {
     #[tokio::test]
     async fn enqueue_with_backpressure_bounds_overflow_buffer() {
         let (tx, mut rx) = mpsc::channel(1);
-        let sender = BackpressureSender::new(tx.clone(), "test", 2);
+        let sender = BackpressureSender::new(tx.clone(), "test", 1);
         assert!(tx.send(1_u8).await.is_ok());
 
         sender.enqueue(2_u8);
+        tokio::task::yield_now().await;
         sender.enqueue(3_u8);
         sender.enqueue(4_u8);
 

--- a/backend/src/api/model/connection_manager.rs
+++ b/backend/src/api/model/connection_manager.rs
@@ -50,13 +50,14 @@ struct BackpressureSender<T> {
     tx: mpsc::Sender<T>,
     state: Arc<Mutex<BackpressureState<T>>>,
     queue_name: &'static str,
+    overflow_capacity: usize,
 }
 
 impl<T> BackpressureSender<T>
 where
     T: Send + 'static,
 {
-    fn new(tx: mpsc::Sender<T>, queue_name: &'static str) -> Self {
+    fn new(tx: mpsc::Sender<T>, queue_name: &'static str, overflow_capacity: usize) -> Self {
         Self {
             tx,
             state: Arc::new(Mutex::new(BackpressureState {
@@ -64,6 +65,7 @@ where
                 draining: false,
             })),
             queue_name,
+            overflow_capacity,
         }
     }
 
@@ -72,6 +74,13 @@ where
         {
             let mut state = lock_backpressure_state(self.state.as_ref());
             if state.draining {
+                if state.overflow.len() >= self.overflow_capacity {
+                    warn!(
+                        "{} overflow buffer full (capacity={}), dropping event",
+                        self.queue_name, self.overflow_capacity
+                    );
+                    return;
+                }
                 state.overflow.push_back(event);
                 return;
             }
@@ -80,6 +89,14 @@ where
                 Ok(()) => return,
                 Err(tokio::sync::mpsc::error::TrySendError::Full(event)) => {
                     state.draining = true;
+                    if state.overflow.len() >= self.overflow_capacity {
+                        warn!(
+                            "{} overflow buffer full (capacity={}), dropping event",
+                            self.queue_name, self.overflow_capacity
+                        );
+                        state.draining = false;
+                        return;
+                    }
                     state.overflow.push_back(event);
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_event)) => {
@@ -538,7 +555,7 @@ impl ConnectionManager {
             shared_stream_manager: Arc::clone(shared_stream_manager),
             event_manager: Arc::clone(event_manager),
             close_socket_signal_tx,
-            cleanup_sender: BackpressureSender::new(cleanup_tx, "cleanup"),
+            cleanup_sender: BackpressureSender::new(cleanup_tx, "cleanup", CLEANUP_QUEUE_CAPACITY),
             socket_activity_tracker: socket_activity_tracker.clone(),
             capacity_notify: Arc::clone(&capacity_notify),
             stream_uid_counter: AtomicU32::new(1),
@@ -1198,7 +1215,7 @@ mod tests {
     #[tokio::test]
     async fn enqueue_with_backpressure_delivers_events_after_queue_full() {
         let (tx, mut rx) = mpsc::channel(1);
-        let sender = BackpressureSender::new(tx.clone(), "test");
+        let sender = BackpressureSender::new(tx.clone(), "test", 2);
         assert!(tx.send(1_u8).await.is_ok());
 
         sender.enqueue(2_u8);
@@ -1212,6 +1229,31 @@ mod tests {
         assert_eq!(
             tokio::time::timeout(Duration::from_secs(1), rx.recv()).await.ok().flatten(),
             Some(3)
+        );
+    }
+
+    #[tokio::test]
+    async fn enqueue_with_backpressure_bounds_overflow_buffer() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let sender = BackpressureSender::new(tx.clone(), "test", 1);
+        assert!(tx.send(1_u8).await.is_ok());
+
+        sender.enqueue(2_u8);
+        sender.enqueue(3_u8);
+        sender.enqueue(4_u8);
+
+        assert_eq!(rx.recv().await, Some(1));
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv()).await.ok().flatten(),
+            Some(2)
+        );
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), rx.recv()).await.ok().flatten(),
+            Some(3)
+        );
+        assert_eq!(
+            tokio::time::timeout(Duration::from_millis(100), rx.recv()).await,
+            Err(tokio::time::error::Elapsed(()))
         );
     }
 

--- a/backend/src/model/config/stream.rs
+++ b/backend/src/model/config/stream.rs
@@ -1,53 +1,8 @@
-use shared::model::{AdmissionStrategyDto, StreamBufferConfigDto, StreamConfigDto};
+use shared::model::{AdmissionStrategy, StreamBufferConfigDto, StreamConfigDto};
 use shared::utils::parse_to_kbps;
 use crate::api::model::TransportStreamBuffer;
 use crate::model::macros;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum AdmissionStrategy {
-    EvictUserSameIpOldest,
-    EvictUserSameIpLatest,
-    EvictUserOldest,
-    EvictUserLatest,
-    GraceInstantStream,
-    GraceHoldStream,
-}
-
-impl From<&AdmissionStrategyDto> for AdmissionStrategy {
-    fn from(dto: &AdmissionStrategyDto) -> Self {
-        match dto {
-            AdmissionStrategyDto::EvictUserSameIpOldest => Self::EvictUserSameIpOldest,
-            AdmissionStrategyDto::EvictUserSameIpLatest => Self::EvictUserSameIpLatest,
-            AdmissionStrategyDto::EvictUserOldest => Self::EvictUserOldest,
-            AdmissionStrategyDto::EvictUserLatest => Self::EvictUserLatest,
-            AdmissionStrategyDto::GraceInstantStream => Self::GraceInstantStream,
-            AdmissionStrategyDto::GraceHoldStream => Self::GraceHoldStream,
-        }
-    }
-}
-
-impl From<&AdmissionStrategy> for AdmissionStrategyDto {
-    fn from(domain: &AdmissionStrategy) -> Self {
-        match domain {
-            AdmissionStrategy::EvictUserSameIpOldest => Self::EvictUserSameIpOldest,
-            AdmissionStrategy::EvictUserSameIpLatest => Self::EvictUserSameIpLatest,
-            AdmissionStrategy::EvictUserOldest => Self::EvictUserOldest,
-            AdmissionStrategy::EvictUserLatest => Self::EvictUserLatest,
-            AdmissionStrategy::GraceInstantStream => Self::GraceInstantStream,
-            AdmissionStrategy::GraceHoldStream => Self::GraceHoldStream,
-        }
-    }
-}
-
-impl AdmissionStrategy {
-    pub fn is_grace(&self) -> bool {
-        matches!(self, Self::GraceInstantStream | Self::GraceHoldStream)
-    }
-
-    pub fn is_grace_hold(&self) -> bool {
-        matches!(self, Self::GraceHoldStream)
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct StreamBufferConfig {
@@ -105,10 +60,7 @@ impl From<&StreamConfigDto> for StreamConfig {
             throttle_str: dto.throttle.clone(),
             throttle_kbps: dto.throttle.as_ref().map_or(0u64, |throttle| parse_to_kbps(throttle).unwrap_or(0u64)),
             shared_burst_buffer_mb: dto.shared_burst_buffer_mb,
-            admission_strategies: dto
-                .admission_strategies
-                .as_ref()
-                .map(|entries| entries.iter().map(AdmissionStrategy::from).collect()),
+            admission_strategies: dto.admission_strategies.clone()
         }
     }
 }
@@ -127,18 +79,15 @@ impl From<&StreamConfig> for StreamConfigDto {
             throttle: instance.throttle_str.clone(),
             throttle_kbps: instance.throttle_kbps,
             shared_burst_buffer_mb: instance.shared_burst_buffer_mb,
-            admission_strategies: instance
-                .admission_strategies
-                .as_ref()
-                .map(|entries| entries.iter().map(AdmissionStrategyDto::from).collect()),
+            admission_strategies: instance.admission_strategies.clone()
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AdmissionStrategy, StreamConfig};
-    use shared::model::{AdmissionStrategyDto, StreamConfigDto};
+    use super::{StreamConfig};
+    use shared::model::{AdmissionStrategy, StreamConfigDto};
 
     #[test]
     fn stream_config_preserves_missing_admission_strategies() {
@@ -180,9 +129,9 @@ mod tests {
         assert_eq!(
             dto.admission_strategies,
             Some(vec![
-                AdmissionStrategyDto::EvictUserOldest,
-                AdmissionStrategyDto::GraceHoldStream,
-                AdmissionStrategyDto::EvictUserLatest,
+                AdmissionStrategy::EvictUserOldest,
+                AdmissionStrategy::GraceHoldStream,
+                AdmissionStrategy::EvictUserLatest,
             ])
         );
     }

--- a/backend/src/model/config/stream.rs
+++ b/backend/src/model/config/stream.rs
@@ -172,6 +172,7 @@ mod tests {
             admission_strategies: Some(vec![
                 AdmissionStrategy::EvictUserOldest,
                 AdmissionStrategy::GraceHoldStream,
+                AdmissionStrategy::EvictUserLatest,
             ]),
         };
 
@@ -181,6 +182,7 @@ mod tests {
             Some(vec![
                 AdmissionStrategyDto::EvictUserOldest,
                 AdmissionStrategyDto::GraceHoldStream,
+                AdmissionStrategyDto::EvictUserLatest,
             ])
         );
     }

--- a/backend/src/model/config/stream.rs
+++ b/backend/src/model/config/stream.rs
@@ -7,6 +7,8 @@ use crate::model::macros;
 pub enum AdmissionStrategy {
     EvictUserSameIpOldest,
     EvictUserSameIpLatest,
+    EvictUserOldest,
+    EvictUserLatest,
     GraceInstantStream,
     GraceHoldStream,
 }
@@ -16,6 +18,8 @@ impl From<&AdmissionStrategyDto> for AdmissionStrategy {
         match dto {
             AdmissionStrategyDto::EvictUserSameIpOldest => Self::EvictUserSameIpOldest,
             AdmissionStrategyDto::EvictUserSameIpLatest => Self::EvictUserSameIpLatest,
+            AdmissionStrategyDto::EvictUserOldest => Self::EvictUserOldest,
+            AdmissionStrategyDto::EvictUserLatest => Self::EvictUserLatest,
             AdmissionStrategyDto::GraceInstantStream => Self::GraceInstantStream,
             AdmissionStrategyDto::GraceHoldStream => Self::GraceHoldStream,
         }
@@ -27,6 +31,8 @@ impl From<&AdmissionStrategy> for AdmissionStrategyDto {
         match domain {
             AdmissionStrategy::EvictUserSameIpOldest => Self::EvictUserSameIpOldest,
             AdmissionStrategy::EvictUserSameIpLatest => Self::EvictUserSameIpLatest,
+            AdmissionStrategy::EvictUserOldest => Self::EvictUserOldest,
+            AdmissionStrategy::EvictUserLatest => Self::EvictUserLatest,
             AdmissionStrategy::GraceInstantStream => Self::GraceInstantStream,
             AdmissionStrategy::GraceHoldStream => Self::GraceHoldStream,
         }
@@ -164,7 +170,7 @@ mod tests {
             throttle_kbps: 0,
             shared_burst_buffer_mb: 1,
             admission_strategies: Some(vec![
-                AdmissionStrategy::EvictUserSameIpOldest,
+                AdmissionStrategy::EvictUserOldest,
                 AdmissionStrategy::GraceHoldStream,
             ]),
         };
@@ -173,7 +179,7 @@ mod tests {
         assert_eq!(
             dto.admission_strategies,
             Some(vec![
-                AdmissionStrategyDto::EvictUserSameIpOldest,
+                AdmissionStrategyDto::EvictUserOldest,
                 AdmissionStrategyDto::GraceHoldStream,
             ])
         );

--- a/docs/src/configuration/connection-handling-sessions-and-reconnects.md
+++ b/docs/src/configuration/connection-handling-sessions-and-reconnects.md
@@ -27,6 +27,12 @@ Without session logic, Tuliprox would often count these operations incorrectly a
 
 A session is the logical playback identity of a user for one stream activity.
 
+Important distinction:
+
+- HLS and catchup rely heavily on logical sessions
+- regular TS/VOD/local playback is counted by active socket-backed stream, not by a long-lived playback session
+- this means opening the same TS/VOD stream twice on two sockets counts as 2 connections
+
 It helps Tuliprox decide:
 
 - is this the same playback?
@@ -46,6 +52,9 @@ Typical behavior:
 - channel switches or quality changes may trigger new requests
 
 For operators this can look like many connections in the logs. Tuliprox therefore tries to treat these follow-up requests as one logical session.
+
+This behavior is intentional for adaptive/session-style playback.
+It is not the general rule for every stream type.
 
 ## Catchup and why it can look even more unstable
 
@@ -72,6 +81,14 @@ In plain language:
 - catchup usually gets a somewhat longer one
 
 ## What the session TTL does not mean
+
+It does not mean that every later socket should always be treated as the same playback.
+
+In particular:
+
+- HLS and catchup may reuse session identity within their configured TTL
+- regular TS/VOD/local playback remains socket-bound and is counted per active stream/socket
+- a second TS/VOD socket therefore consumes another user connection or soft slot
 
 The TTL does not automatically mean:
 
@@ -182,6 +199,9 @@ Depending on timing, Tuliprox may:
 - keep the session briefly
 - allow a resume
 - or discard the session once the window expires
+
+This is most relevant for HLS and catchup continuity.
+Regular TS/VOD/local playback should be understood primarily as socket-bound admission.
 
 ## What matters when shared streams and sessions meet
 

--- a/docs/src/configuration/connection-handling.md
+++ b/docs/src/configuration/connection-handling.md
@@ -87,6 +87,12 @@ This matters especially for:
 
 - HLS
 - catchup
+
+It does not apply equally to every stream type:
+
+- HLS and catchup are session-oriented because many follow-up HTTP requests still belong to one logical playback
+- regular TS/VOD/local playback is socket-bound for admission and connection counting
+- for TS/VOD, a second socket is a second connection even if it is the same user, same IP, and same stream
 - quick reconnects
 - channel switches with a brief overlap
 
@@ -133,6 +139,13 @@ Examples:
 - some players briefly overlap old and new requests during seeks or channel switches
 
 If Tuliprox recognizes the same playback, not every follow-up request is treated like a completely new stream.
+
+This recognition is mainly relevant for HLS and catchup style playback.
+Regular TS/VOD playback is intentionally stricter:
+
+- one active socket-backed stream counts as one connection
+- a parallel reopen on another socket counts as another connection
+- if `max_connections` is already exhausted, only a soft slot, admission strategy, or rejection remains
 
 ### 2. Normal connection
 
@@ -245,6 +258,17 @@ If it is the best valid victim, it can be terminated completely.
 ### A kick ends both the stream and its session
 
 When a connection is deliberately kicked, Tuliprox should not immediately treat the same session as still valid.
+
+### Admission strategy order is semantic
+
+Admission strategies are not a set. They are processed from top to bottom.
+
+That means broader user-wide eviction rules can shadow narrower same-IP rules when they use the same oldest/latest policy.
+
+Recommended:
+
+- `evict_user_same_ip_oldest` before `evict_user_oldest`
+- `evict_user_same_ip_latest` before `evict_user_latest`
 
 ## Operator checklist
 

--- a/docs/src/configuration/connection-handling.md
+++ b/docs/src/configuration/connection-handling.md
@@ -156,6 +156,8 @@ Examples:
 - `GraceHoldStream`
 - `EvictUserSameIpOldest`
 - `EvictUserSameIpLatest`
+- `EvictUserOldest`
+- `EvictUserLatest`
 
 These rules are only evaluated after ordinary user admission is already exhausted.
 

--- a/docs/src/configuration/connection-handling.md
+++ b/docs/src/configuration/connection-handling.md
@@ -259,6 +259,23 @@ If it is the best valid victim, it can be terminated completely.
 
 When a connection is deliberately kicked, Tuliprox should not immediately treat the same session as still valid.
 
+### Recent eviction does not create a full user cooldown
+
+Tuliprox now distinguishes between:
+
+- a normal reconnect that fits into a free hard slot or soft slot
+- an immediate reconnect of the just-evicted playback that would only work by kicking another stream again
+
+Only the second case is temporarily suppressed.
+
+Important:
+
+- for HLS/catchup, this protection is scoped to the same session identity where Tuliprox has a stable session token
+- for socket-bound TS/VOD/local playback, Tuliprox uses a short same-user, same-IP, same-channel winner protection instead
+- switching to a different channel is not blocked by it
+- soft admission can still succeed if a soft slot is free
+- the goal is to stop endless eviction ping-pong between aggressive player reconnect loops
+
 ### Admission strategy order is semantic
 
 Admission strategies are not a set. They are processed from top to bottom.

--- a/docs/src/configuration/reverse-proxy.md
+++ b/docs/src/configuration/reverse-proxy.md
@@ -74,6 +74,15 @@ node -e "console.log(require('crypto').randomBytes(16).toString('hex').toUpperCa
 
 This sub-block defines how Tuliprox maintains stream stability, buffers data, and handles HLS/Catchup session affinity.
 
+Admission strategies in this block can optionally evict an existing stream after normal and soft user admission are already exhausted:
+
+* `evict_user_same_ip_oldest`
+* `evict_user_same_ip_latest`
+* `evict_user_oldest`
+* `evict_user_latest`
+* `grace_instant_stream`
+* `grace_hold_stream`
+
 ```yaml
 reverse_proxy:
   stream:

--- a/docs/src/configuration/reverse-proxy.md
+++ b/docs/src/configuration/reverse-proxy.md
@@ -83,6 +83,17 @@ Admission strategies in this block can optionally evict an existing stream after
 * `grace_instant_stream`
 * `grace_hold_stream`
 
+Order matters.
+
+If you want same-IP eviction to be preferred, place the same-IP rule before the broader user-wide rule with the same oldest/latest policy.
+
+Examples:
+
+* valid: `evict_user_same_ip_oldest`, then `evict_user_oldest`
+* invalid: `evict_user_oldest`, then `evict_user_same_ip_oldest`
+* valid: `evict_user_same_ip_latest`, then `evict_user_latest`
+* invalid: `evict_user_latest`, then `evict_user_same_ip_latest`
+
 ```yaml
 reverse_proxy:
   stream:
@@ -162,6 +173,12 @@ to maintain account affinity:
   The reservation keeps the provider account stable between segment fetches.
 * **Catchup (`45s`):** Keeps the reservation alive during seeking and reconnects.
 * **Note:** Channel switches from the same client immediately take over the reservation, bypassing the TTL.
+
+Important boundary:
+
+* These TTLs are for HLS/catchup style session continuity.
+* Regular TS/VOD/local playback is socket-bound for admission and user-connection counting.
+* Opening the same TS/VOD stream on a second socket consumes another connection or soft slot.
 
 ---
 

--- a/frontend/public/assets/i18n/en.json
+++ b/frontend/public/assets/i18n/en.json
@@ -611,7 +611,7 @@
       "URL": "Target URL that receives the notification webhook."
     },
     "REVERSE_PROXY_CONFIG": {
-      "ADMISSION_STRATEGIES": "Defines what Tuliprox may still try after the normal user admission is already exhausted.\n\nUse this to control short transition grace during switching or to evict an existing same-IP stream instead of rejecting the new request immediately.\n\nStrategies are evaluated from top to bottom.\n\nGrace strategies only work when `grace_period_millis` is greater than 0. Only one grace strategy can be active at a time.",
+      "ADMISSION_STRATEGIES": "Defines what Tuliprox may still try after the normal user admission is already exhausted.\n\nUse this to control short transition grace during switching or to evict an existing user stream, either from the same IP only or across the whole user account, instead of rejecting the new request immediately.\n\nStrategies are evaluated from top to bottom.\n\nGrace strategies only work when `grace_period_millis` is greater than 0. Only one grace strategy can be active at a time.",
       "FAILOVER_REDIRECT_PATTERNS": "Regex patterns determining which HTTP error responses trigger an automatic failover rotation.",
       "RESOURCE_REWRITE_DISABLED": "If enabled, URL rewriting for logos and EPG is disabled (also disables caching).",
       "REWRITE_SECRET": "Persistent secret for stable resource URLs across restarts. \nExample:\n```\nreverse_proxy:\n  rewrite_secret: A1B2C3D4E5F60718293A4B5C6D7E8F90\n```",
@@ -808,6 +808,8 @@
     "ADD_WATCH": "Add Watch",
     "ADMISSION_STRATEGY_EVICT_USER_SAME_IP_LATEST": "Evict same-IP latest stream",
     "ADMISSION_STRATEGY_EVICT_USER_SAME_IP_OLDEST": "Evict same-IP oldest stream",
+    "ADMISSION_STRATEGY_EVICT_USER_LATEST": "Evict user latest stream",
+    "ADMISSION_STRATEGY_EVICT_USER_OLDEST": "Evict user oldest stream",
     "ADMISSION_STRATEGY_GRACE_HOLD_STREAM": "Grace hold stream",
     "ADMISSION_STRATEGY_GRACE_INSTANT_STREAM": "Grace instant stream",
     "ADVANCED": "Advanced",

--- a/frontend/src/app/components/config/reverse_proxy_config_view.rs
+++ b/frontend/src/app/components/config/reverse_proxy_config_view.rs
@@ -284,8 +284,12 @@ fn add_admission_strategy_tag(current: &[String], strategy: AdmissionStrategyDto
     // When adding a same-IP eviction rule, insert it before the broader user-wide
     // rule (if present) so the backend ordering validation is satisfied.
     let broader_tag: Option<&'static str> = match strategy {
-        AdmissionStrategyDto::EvictUserSameIpOldest => Some(admission_strategy_tag(AdmissionStrategyDto::EvictUserOldest)),
-        AdmissionStrategyDto::EvictUserSameIpLatest => Some(admission_strategy_tag(AdmissionStrategyDto::EvictUserLatest)),
+        AdmissionStrategyDto::EvictUserSameIpOldest => {
+            Some(admission_strategy_tag(AdmissionStrategyDto::EvictUserOldest))
+        }
+        AdmissionStrategyDto::EvictUserSameIpLatest => {
+            Some(admission_strategy_tag(AdmissionStrategyDto::EvictUserLatest))
+        }
         _ => None,
     };
     if let Some(broader) = broader_tag {

--- a/frontend/src/app/components/config/reverse_proxy_config_view.rs
+++ b/frontend/src/app/components/config/reverse_proxy_config_view.rs
@@ -278,9 +278,23 @@ fn available_admission_strategies(selected_tags: &[String], grace_period_millis:
 fn add_admission_strategy_tag(current: &[String], strategy: AdmissionStrategyDto) -> Vec<String> {
     let mut next = current.to_vec();
     let tag = admission_strategy_tag(strategy).to_string();
-    if !next.iter().any(|selected| selected == &tag) {
-        next.push(tag);
+    if next.iter().any(|selected| selected == &tag) {
+        return next;
     }
+    // When adding a same-IP eviction rule, insert it before the broader user-wide
+    // rule (if present) so the backend ordering validation is satisfied.
+    let broader_tag: Option<&'static str> = match strategy {
+        AdmissionStrategyDto::EvictUserSameIpOldest => Some(admission_strategy_tag(AdmissionStrategyDto::EvictUserOldest)),
+        AdmissionStrategyDto::EvictUserSameIpLatest => Some(admission_strategy_tag(AdmissionStrategyDto::EvictUserLatest)),
+        _ => None,
+    };
+    if let Some(broader) = broader_tag {
+        if let Some(pos) = next.iter().position(|t| t == broader) {
+            next.insert(pos, tag);
+            return next;
+        }
+    }
+    next.push(tag);
     next
 }
 

--- a/frontend/src/app/components/config/reverse_proxy_config_view.rs
+++ b/frontend/src/app/components/config/reverse_proxy_config_view.rs
@@ -82,6 +82,8 @@ const LABEL_QOS_AGGREGATION_ENABLED: &str = "LABEL.QOS_AGGREGATION_ENABLED";
 const LABEL_INTERVAL_SECS: &str = "LABEL.INTERVAL_SECS";
 const LABEL_ADMISSION_STRATEGY_EVICT_USER_SAME_IP_OLDEST: &str = "LABEL.ADMISSION_STRATEGY_EVICT_USER_SAME_IP_OLDEST";
 const LABEL_ADMISSION_STRATEGY_EVICT_USER_SAME_IP_LATEST: &str = "LABEL.ADMISSION_STRATEGY_EVICT_USER_SAME_IP_LATEST";
+const LABEL_ADMISSION_STRATEGY_EVICT_USER_OLDEST: &str = "LABEL.ADMISSION_STRATEGY_EVICT_USER_OLDEST";
+const LABEL_ADMISSION_STRATEGY_EVICT_USER_LATEST: &str = "LABEL.ADMISSION_STRATEGY_EVICT_USER_LATEST";
 const LABEL_ADMISSION_STRATEGY_GRACE_INSTANT_STREAM: &str = "LABEL.ADMISSION_STRATEGY_GRACE_INSTANT_STREAM";
 const LABEL_ADMISSION_STRATEGY_GRACE_HOLD_STREAM: &str = "LABEL.ADMISSION_STRATEGY_GRACE_HOLD_STREAM";
 
@@ -134,6 +136,8 @@ fn admission_strategy_tag(strategy: AdmissionStrategyDto) -> &'static str {
     match strategy {
         AdmissionStrategyDto::EvictUserSameIpOldest => "evict_user_same_ip_oldest",
         AdmissionStrategyDto::EvictUserSameIpLatest => "evict_user_same_ip_latest",
+        AdmissionStrategyDto::EvictUserOldest => "evict_user_oldest",
+        AdmissionStrategyDto::EvictUserLatest => "evict_user_latest",
         AdmissionStrategyDto::GraceInstantStream => "grace_instant_stream",
         AdmissionStrategyDto::GraceHoldStream => "grace_hold_stream",
     }
@@ -143,6 +147,8 @@ fn parse_admission_strategy_tag(tag: &str) -> Option<AdmissionStrategyDto> {
     match tag.trim() {
         "evict_user_same_ip_oldest" => Some(AdmissionStrategyDto::EvictUserSameIpOldest),
         "evict_user_same_ip_latest" => Some(AdmissionStrategyDto::EvictUserSameIpLatest),
+        "evict_user_oldest" => Some(AdmissionStrategyDto::EvictUserOldest),
+        "evict_user_latest" => Some(AdmissionStrategyDto::EvictUserLatest),
         "grace_instant_stream" => Some(AdmissionStrategyDto::GraceInstantStream),
         "grace_hold_stream" => Some(AdmissionStrategyDto::GraceHoldStream),
         _ => None,
@@ -153,6 +159,8 @@ fn admission_strategy_label_key(strategy: AdmissionStrategyDto) -> &'static str 
     match strategy {
         AdmissionStrategyDto::EvictUserSameIpOldest => LABEL_ADMISSION_STRATEGY_EVICT_USER_SAME_IP_OLDEST,
         AdmissionStrategyDto::EvictUserSameIpLatest => LABEL_ADMISSION_STRATEGY_EVICT_USER_SAME_IP_LATEST,
+        AdmissionStrategyDto::EvictUserOldest => LABEL_ADMISSION_STRATEGY_EVICT_USER_OLDEST,
+        AdmissionStrategyDto::EvictUserLatest => LABEL_ADMISSION_STRATEGY_EVICT_USER_LATEST,
         AdmissionStrategyDto::GraceInstantStream => LABEL_ADMISSION_STRATEGY_GRACE_INSTANT_STREAM,
         AdmissionStrategyDto::GraceHoldStream => LABEL_ADMISSION_STRATEGY_GRACE_HOLD_STREAM,
     }
@@ -162,6 +170,8 @@ fn admission_strategy_label(translate: &YewI18n, strategy: AdmissionStrategyDto)
     t_safe(translate, admission_strategy_label_key(strategy)).unwrap_or_else(|| match strategy {
         AdmissionStrategyDto::EvictUserSameIpOldest => "Evict same-IP oldest stream".to_string(),
         AdmissionStrategyDto::EvictUserSameIpLatest => "Evict same-IP latest stream".to_string(),
+        AdmissionStrategyDto::EvictUserOldest => "Evict user oldest stream".to_string(),
+        AdmissionStrategyDto::EvictUserLatest => "Evict user latest stream".to_string(),
         AdmissionStrategyDto::GraceInstantStream => "Grace instant stream".to_string(),
         AdmissionStrategyDto::GraceHoldStream => "Grace hold stream".to_string(),
     })
@@ -249,6 +259,8 @@ fn available_admission_strategies(selected_tags: &[String], grace_period_millis:
     [
         AdmissionStrategyDto::EvictUserSameIpOldest,
         AdmissionStrategyDto::EvictUserSameIpLatest,
+        AdmissionStrategyDto::EvictUserOldest,
+        AdmissionStrategyDto::EvictUserLatest,
         AdmissionStrategyDto::GraceInstantStream,
         AdmissionStrategyDto::GraceHoldStream,
     ]
@@ -1125,24 +1137,20 @@ mod tests {
     #[test]
     fn admission_strategy_tags_roundtrip() {
         let tags = admission_strategy_tags(Some(&vec![
-            AdmissionStrategyDto::EvictUserSameIpOldest,
+            AdmissionStrategyDto::EvictUserOldest,
             AdmissionStrategyDto::GraceHoldStream,
         ]))
         .unwrap_or_default();
         assert_eq!(
             parse_admission_strategy_tags(Some(&tags)),
-            Some(vec![AdmissionStrategyDto::EvictUserSameIpOldest, AdmissionStrategyDto::GraceHoldStream,])
+            Some(vec![AdmissionStrategyDto::EvictUserOldest, AdmissionStrategyDto::GraceHoldStream,])
         );
     }
 
     #[test]
     fn invalid_admission_strategy_tags_are_ignored() {
-        let tags = vec![
-            "evict_user_same_ip_latest".to_string(),
-            "not-a-strategy".to_string(),
-            "evict_user_same_ip_latest".to_string(),
-        ];
-        assert_eq!(parse_admission_strategy_tags(Some(&tags)), Some(vec![AdmissionStrategyDto::EvictUserSameIpLatest]));
+        let tags = vec!["evict_user_latest".to_string(), "not-a-strategy".to_string(), "evict_user_latest".to_string()];
+        assert_eq!(parse_admission_strategy_tags(Some(&tags)), Some(vec![AdmissionStrategyDto::EvictUserLatest]));
     }
 
     #[test]
@@ -1163,6 +1171,7 @@ mod tests {
         assert!(!available.contains(&AdmissionStrategyDto::GraceInstantStream));
         assert!(!available.contains(&AdmissionStrategyDto::GraceHoldStream));
         assert!(available.contains(&AdmissionStrategyDto::EvictUserSameIpOldest));
+        assert!(available.contains(&AdmissionStrategyDto::EvictUserOldest));
     }
 
     #[test]
@@ -1172,6 +1181,8 @@ mod tests {
         assert!(!available.contains(&AdmissionStrategyDto::GraceHoldStream));
         assert!(available.contains(&AdmissionStrategyDto::EvictUserSameIpOldest));
         assert!(available.contains(&AdmissionStrategyDto::EvictUserSameIpLatest));
+        assert!(available.contains(&AdmissionStrategyDto::EvictUserOldest));
+        assert!(available.contains(&AdmissionStrategyDto::EvictUserLatest));
     }
 
     #[test]

--- a/frontend/src/app/components/config/reverse_proxy_config_view.rs
+++ b/frontend/src/app/components/config/reverse_proxy_config_view.rs
@@ -1232,4 +1232,19 @@ mod tests {
             Some(vec![AdmissionStrategyDto::EvictUserSameIpOldest])
         );
     }
+
+    #[test]
+    fn add_admission_strategy_enforces_narrower_before_broader() {
+        let current = vec!["evict_user_oldest".to_string()];
+        let new_tags = add_admission_strategy_tag(&current, "evict_user_same_ip_oldest");
+        assert_eq!(new_tags, vec!["evict_user_same_ip_oldest".to_string(), "evict_user_oldest".to_string()]);
+    }
+
+    #[test]
+    fn move_admission_strategy_reverts_invalid_order() {
+        let current = vec!["evict_user_same_ip_oldest".to_string(), "evict_user_oldest".to_string()];
+        // Attempt to move broader EvictUserOldest up before narrower EvictUserSameIpOldest
+        let next = move_admission_strategy_tag(&current, 1, -1);
+        assert_eq!(next, current);
+    }
 }

--- a/frontend/src/app/components/config/reverse_proxy_config_view.rs
+++ b/frontend/src/app/components/config/reverse_proxy_config_view.rs
@@ -281,19 +281,16 @@ fn add_admission_strategy_tag(current: &[String], strategy: AdmissionStrategyDto
     if next.iter().any(|selected| selected == &tag) {
         return next;
     }
-    // When adding a same-IP eviction rule, insert it before the broader user-wide
+    // When adding a same-IP eviction rule, insert it before any broader user-wide
     // rule (if present) so the backend ordering validation is satisfied.
-    let broader_tag: Option<&'static str> = match strategy {
-        AdmissionStrategyDto::EvictUserSameIpOldest => {
-            Some(admission_strategy_tag(AdmissionStrategyDto::EvictUserOldest))
-        }
-        AdmissionStrategyDto::EvictUserSameIpLatest => {
-            Some(admission_strategy_tag(AdmissionStrategyDto::EvictUserLatest))
-        }
-        _ => None,
-    };
-    if let Some(broader) = broader_tag {
-        if let Some(pos) = next.iter().position(|t| t == broader) {
+    let is_narrower =
+        matches!(strategy, AdmissionStrategyDto::EvictUserSameIpOldest | AdmissionStrategyDto::EvictUserSameIpLatest);
+    if is_narrower {
+        let broader_oldest = admission_strategy_tag(AdmissionStrategyDto::EvictUserOldest);
+        let broader_latest = admission_strategy_tag(AdmissionStrategyDto::EvictUserLatest);
+
+        let earliest_pos = next.iter().position(|t| t == broader_oldest || t == broader_latest);
+        if let Some(pos) = earliest_pos {
             next.insert(pos, tag);
             return next;
         }

--- a/frontend/src/app/components/config/reverse_proxy_config_view.rs
+++ b/frontend/src/app/components/config/reverse_proxy_config_view.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 use shared::{
     model::{
-        AdmissionStrategyDto, CacheConfigDto, GeoIpConfigDto, QosAggregationConfigDto, RateLimitConfigDto,
+        AdmissionStrategy, CacheConfigDto, GeoIpConfigDto, QosAggregationConfigDto, RateLimitConfigDto,
         ResourceRetryConfigDto, ReverseProxyConfigDto, ReverseProxyDisabledHeaderConfigDto, StreamBufferConfigDto,
         StreamConfigDto, StreamHistoryConfigDto,
     },
@@ -132,53 +132,53 @@ pub struct AdmissionStrategiesDto {
     pub strategies: Option<Vec<String>>,
 }
 
-fn admission_strategy_tag(strategy: AdmissionStrategyDto) -> &'static str {
+fn admission_strategy_tag(strategy: AdmissionStrategy) -> &'static str {
     match strategy {
-        AdmissionStrategyDto::EvictUserSameIpOldest => "evict_user_same_ip_oldest",
-        AdmissionStrategyDto::EvictUserSameIpLatest => "evict_user_same_ip_latest",
-        AdmissionStrategyDto::EvictUserOldest => "evict_user_oldest",
-        AdmissionStrategyDto::EvictUserLatest => "evict_user_latest",
-        AdmissionStrategyDto::GraceInstantStream => "grace_instant_stream",
-        AdmissionStrategyDto::GraceHoldStream => "grace_hold_stream",
+        AdmissionStrategy::EvictUserSameIpOldest => "evict_user_same_ip_oldest",
+        AdmissionStrategy::EvictUserSameIpLatest => "evict_user_same_ip_latest",
+        AdmissionStrategy::EvictUserOldest => "evict_user_oldest",
+        AdmissionStrategy::EvictUserLatest => "evict_user_latest",
+        AdmissionStrategy::GraceInstantStream => "grace_instant_stream",
+        AdmissionStrategy::GraceHoldStream => "grace_hold_stream",
     }
 }
 
-fn parse_admission_strategy_tag(tag: &str) -> Option<AdmissionStrategyDto> {
+fn parse_admission_strategy_tag(tag: &str) -> Option<AdmissionStrategy> {
     match tag.trim() {
-        "evict_user_same_ip_oldest" => Some(AdmissionStrategyDto::EvictUserSameIpOldest),
-        "evict_user_same_ip_latest" => Some(AdmissionStrategyDto::EvictUserSameIpLatest),
-        "evict_user_oldest" => Some(AdmissionStrategyDto::EvictUserOldest),
-        "evict_user_latest" => Some(AdmissionStrategyDto::EvictUserLatest),
-        "grace_instant_stream" => Some(AdmissionStrategyDto::GraceInstantStream),
-        "grace_hold_stream" => Some(AdmissionStrategyDto::GraceHoldStream),
+        "evict_user_same_ip_oldest" => Some(AdmissionStrategy::EvictUserSameIpOldest),
+        "evict_user_same_ip_latest" => Some(AdmissionStrategy::EvictUserSameIpLatest),
+        "evict_user_oldest" => Some(AdmissionStrategy::EvictUserOldest),
+        "evict_user_latest" => Some(AdmissionStrategy::EvictUserLatest),
+        "grace_instant_stream" => Some(AdmissionStrategy::GraceInstantStream),
+        "grace_hold_stream" => Some(AdmissionStrategy::GraceHoldStream),
         _ => None,
     }
 }
 
-fn admission_strategy_label_key(strategy: AdmissionStrategyDto) -> &'static str {
+fn admission_strategy_label_key(strategy: AdmissionStrategy) -> &'static str {
     match strategy {
-        AdmissionStrategyDto::EvictUserSameIpOldest => LABEL_ADMISSION_STRATEGY_EVICT_USER_SAME_IP_OLDEST,
-        AdmissionStrategyDto::EvictUserSameIpLatest => LABEL_ADMISSION_STRATEGY_EVICT_USER_SAME_IP_LATEST,
-        AdmissionStrategyDto::EvictUserOldest => LABEL_ADMISSION_STRATEGY_EVICT_USER_OLDEST,
-        AdmissionStrategyDto::EvictUserLatest => LABEL_ADMISSION_STRATEGY_EVICT_USER_LATEST,
-        AdmissionStrategyDto::GraceInstantStream => LABEL_ADMISSION_STRATEGY_GRACE_INSTANT_STREAM,
-        AdmissionStrategyDto::GraceHoldStream => LABEL_ADMISSION_STRATEGY_GRACE_HOLD_STREAM,
+        AdmissionStrategy::EvictUserSameIpOldest => LABEL_ADMISSION_STRATEGY_EVICT_USER_SAME_IP_OLDEST,
+        AdmissionStrategy::EvictUserSameIpLatest => LABEL_ADMISSION_STRATEGY_EVICT_USER_SAME_IP_LATEST,
+        AdmissionStrategy::EvictUserOldest => LABEL_ADMISSION_STRATEGY_EVICT_USER_OLDEST,
+        AdmissionStrategy::EvictUserLatest => LABEL_ADMISSION_STRATEGY_EVICT_USER_LATEST,
+        AdmissionStrategy::GraceInstantStream => LABEL_ADMISSION_STRATEGY_GRACE_INSTANT_STREAM,
+        AdmissionStrategy::GraceHoldStream => LABEL_ADMISSION_STRATEGY_GRACE_HOLD_STREAM,
     }
 }
 
-fn admission_strategy_label(translate: &YewI18n, strategy: AdmissionStrategyDto) -> String {
+fn admission_strategy_label(translate: &YewI18n, strategy: AdmissionStrategy) -> String {
     t_safe(translate, admission_strategy_label_key(strategy)).unwrap_or_else(|| match strategy {
-        AdmissionStrategyDto::EvictUserSameIpOldest => "Evict same-IP oldest stream".to_string(),
-        AdmissionStrategyDto::EvictUserSameIpLatest => "Evict same-IP latest stream".to_string(),
-        AdmissionStrategyDto::EvictUserOldest => "Evict user oldest stream".to_string(),
-        AdmissionStrategyDto::EvictUserLatest => "Evict user latest stream".to_string(),
-        AdmissionStrategyDto::GraceInstantStream => "Grace instant stream".to_string(),
-        AdmissionStrategyDto::GraceHoldStream => "Grace hold stream".to_string(),
+        AdmissionStrategy::EvictUserSameIpOldest => "Evict same-IP oldest stream".to_string(),
+        AdmissionStrategy::EvictUserSameIpLatest => "Evict same-IP latest stream".to_string(),
+        AdmissionStrategy::EvictUserOldest => "Evict user oldest stream".to_string(),
+        AdmissionStrategy::EvictUserLatest => "Evict user latest stream".to_string(),
+        AdmissionStrategy::GraceInstantStream => "Grace instant stream".to_string(),
+        AdmissionStrategy::GraceHoldStream => "Grace hold stream".to_string(),
     })
 }
 
-fn is_grace_strategy(strategy: AdmissionStrategyDto) -> bool {
-    matches!(strategy, AdmissionStrategyDto::GraceInstantStream | AdmissionStrategyDto::GraceHoldStream)
+fn is_grace_strategy(strategy: AdmissionStrategy) -> bool {
+    matches!(strategy, AdmissionStrategy::GraceInstantStream | AdmissionStrategy::GraceHoldStream)
 }
 
 fn is_grace_strategy_tag(tag: &str) -> bool {
@@ -186,11 +186,11 @@ fn is_grace_strategy_tag(tag: &str) -> bool {
     tag.starts_with("grace_") || parse_admission_strategy_tag(tag).is_some_and(is_grace_strategy)
 }
 
-fn admission_strategy_tags(strategies: Option<&Vec<AdmissionStrategyDto>>) -> Option<Vec<String>> {
+fn admission_strategy_tags(strategies: Option<&Vec<AdmissionStrategy>>) -> Option<Vec<String>> {
     strategies.map(|entries| entries.iter().map(|entry| admission_strategy_tag(*entry).to_string()).collect())
 }
 
-fn parse_admission_strategy_tags(tags: Option<&[String]>) -> Option<Vec<AdmissionStrategyDto>> {
+fn parse_admission_strategy_tags(tags: Option<&[String]>) -> Option<Vec<AdmissionStrategy>> {
     let tags = tags?;
     let mut parsed = Vec::new();
     for tag in tags {
@@ -212,9 +212,9 @@ fn filter_disabled_grace_strategy_tags(tags: Vec<String>, grace_period_millis: u
 }
 
 fn filter_disabled_grace_strategies(
-    strategies: Option<Vec<AdmissionStrategyDto>>,
+    strategies: Option<Vec<AdmissionStrategy>>,
     grace_period_millis: u64,
-) -> Option<Vec<AdmissionStrategyDto>> {
+) -> Option<Vec<AdmissionStrategy>> {
     strategies.map(|entries| {
         if grace_period_millis == 0 {
             entries.into_iter().filter(|strategy| !is_grace_strategy(*strategy)).collect()
@@ -235,9 +235,9 @@ fn legacy_admission_strategy_tags(stream: &StreamConfigDto) -> Vec<String> {
         Vec::new()
     } else {
         vec![admission_strategy_tag(if stream.grace_period_hold_stream {
-            AdmissionStrategyDto::GraceHoldStream
+            AdmissionStrategy::GraceHoldStream
         } else {
-            AdmissionStrategyDto::GraceInstantStream
+            AdmissionStrategy::GraceInstantStream
         })
         .to_string()]
     }
@@ -253,16 +253,16 @@ fn displayed_admission_strategy_tags(state: &AdmissionStrategiesDto, stream: &St
     )
 }
 
-fn available_admission_strategies(selected_tags: &[String], grace_period_millis: u64) -> Vec<AdmissionStrategyDto> {
+fn available_admission_strategies(selected_tags: &[String], grace_period_millis: u64) -> Vec<AdmissionStrategy> {
     let has_grace = selected_tags.iter().filter_map(|tag| parse_admission_strategy_tag(tag)).any(is_grace_strategy);
 
     [
-        AdmissionStrategyDto::EvictUserSameIpOldest,
-        AdmissionStrategyDto::EvictUserSameIpLatest,
-        AdmissionStrategyDto::EvictUserOldest,
-        AdmissionStrategyDto::EvictUserLatest,
-        AdmissionStrategyDto::GraceInstantStream,
-        AdmissionStrategyDto::GraceHoldStream,
+        AdmissionStrategy::EvictUserSameIpOldest,
+        AdmissionStrategy::EvictUserSameIpLatest,
+        AdmissionStrategy::EvictUserOldest,
+        AdmissionStrategy::EvictUserLatest,
+        AdmissionStrategy::GraceInstantStream,
+        AdmissionStrategy::GraceHoldStream,
     ]
     .into_iter()
     .filter(|strategy| {
@@ -275,7 +275,7 @@ fn available_admission_strategies(selected_tags: &[String], grace_period_millis:
     .collect()
 }
 
-fn add_admission_strategy_tag(current: &[String], strategy: AdmissionStrategyDto) -> Vec<String> {
+fn add_admission_strategy_tag(current: &[String], strategy: AdmissionStrategy) -> Vec<String> {
     let mut next = current.to_vec();
     let tag = admission_strategy_tag(strategy).to_string();
     if next.iter().any(|selected| selected == &tag) {
@@ -284,10 +284,10 @@ fn add_admission_strategy_tag(current: &[String], strategy: AdmissionStrategyDto
     // When adding a same-IP eviction rule, insert it before any broader user-wide
     // rule (if present) so the backend ordering validation is satisfied.
     let is_narrower =
-        matches!(strategy, AdmissionStrategyDto::EvictUserSameIpOldest | AdmissionStrategyDto::EvictUserSameIpLatest);
+        matches!(strategy, AdmissionStrategy::EvictUserSameIpOldest | AdmissionStrategy::EvictUserSameIpLatest);
     if is_narrower {
-        let broader_oldest = admission_strategy_tag(AdmissionStrategyDto::EvictUserOldest);
-        let broader_latest = admission_strategy_tag(AdmissionStrategyDto::EvictUserLatest);
+        let broader_oldest = admission_strategy_tag(AdmissionStrategy::EvictUserOldest);
+        let broader_latest = admission_strategy_tag(AdmissionStrategy::EvictUserLatest);
 
         let earliest_pos = next.iter().position(|t| t == broader_oldest || t == broader_latest);
         if let Some(pos) = earliest_pos {
@@ -313,7 +313,7 @@ fn move_admission_strategy_tag(current: &[String], index: usize, delta: isize) -
         if index < next.len() && target_index < next.len() {
             next.swap(index, target_index);
             // Reject the move if it would create an invalid ordering (broader before narrower).
-            let strategy_dtos: Vec<AdmissionStrategyDto> =
+            let strategy_dtos: Vec<AdmissionStrategy> =
                 next.iter().filter_map(|t| parse_admission_strategy_tag(t)).collect();
             if !shared::model::is_valid_admission_strategy_order(&strategy_dtos) {
                 next.swap(index, target_index); // revert
@@ -1158,26 +1158,26 @@ mod tests {
     #[test]
     fn admission_strategy_tags_roundtrip() {
         let tags = admission_strategy_tags(Some(&vec![
-            AdmissionStrategyDto::EvictUserOldest,
-            AdmissionStrategyDto::GraceHoldStream,
+            AdmissionStrategy::EvictUserOldest,
+            AdmissionStrategy::GraceHoldStream,
         ]))
         .unwrap_or_default();
         assert_eq!(
             parse_admission_strategy_tags(Some(&tags)),
-            Some(vec![AdmissionStrategyDto::EvictUserOldest, AdmissionStrategyDto::GraceHoldStream,])
+            Some(vec![AdmissionStrategy::EvictUserOldest, AdmissionStrategy::GraceHoldStream,])
         );
     }
 
     #[test]
     fn admission_strategy_tags_roundtrip_evict_user_latest() {
-        let tags = admission_strategy_tags(Some(&vec![AdmissionStrategyDto::EvictUserLatest])).unwrap_or_default();
-        assert_eq!(parse_admission_strategy_tags(Some(&tags)), Some(vec![AdmissionStrategyDto::EvictUserLatest]));
+        let tags = admission_strategy_tags(Some(&vec![AdmissionStrategy::EvictUserLatest])).unwrap_or_default();
+        assert_eq!(parse_admission_strategy_tags(Some(&tags)), Some(vec![AdmissionStrategy::EvictUserLatest]));
     }
 
     #[test]
     fn invalid_admission_strategy_tags_are_ignored() {
         let tags = vec!["evict_user_latest".to_string(), "not-a-strategy".to_string(), "evict_user_latest".to_string()];
-        assert_eq!(parse_admission_strategy_tags(Some(&tags)), Some(vec![AdmissionStrategyDto::EvictUserLatest]));
+        assert_eq!(parse_admission_strategy_tags(Some(&tags)), Some(vec![AdmissionStrategy::EvictUserLatest]));
     }
 
     #[test]
@@ -1195,21 +1195,21 @@ mod tests {
     #[test]
     fn available_admission_strategies_hide_second_grace_option() {
         let available = available_admission_strategies(&["grace_hold_stream".to_string()], 2_000);
-        assert!(!available.contains(&AdmissionStrategyDto::GraceInstantStream));
-        assert!(!available.contains(&AdmissionStrategyDto::GraceHoldStream));
-        assert!(available.contains(&AdmissionStrategyDto::EvictUserSameIpOldest));
-        assert!(available.contains(&AdmissionStrategyDto::EvictUserOldest));
+        assert!(!available.contains(&AdmissionStrategy::GraceInstantStream));
+        assert!(!available.contains(&AdmissionStrategy::GraceHoldStream));
+        assert!(available.contains(&AdmissionStrategy::EvictUserSameIpOldest));
+        assert!(available.contains(&AdmissionStrategy::EvictUserOldest));
     }
 
     #[test]
     fn available_admission_strategies_hide_grace_when_disabled() {
         let available = available_admission_strategies(&[], 0);
-        assert!(!available.contains(&AdmissionStrategyDto::GraceInstantStream));
-        assert!(!available.contains(&AdmissionStrategyDto::GraceHoldStream));
-        assert!(available.contains(&AdmissionStrategyDto::EvictUserSameIpOldest));
-        assert!(available.contains(&AdmissionStrategyDto::EvictUserSameIpLatest));
-        assert!(available.contains(&AdmissionStrategyDto::EvictUserOldest));
-        assert!(available.contains(&AdmissionStrategyDto::EvictUserLatest));
+        assert!(!available.contains(&AdmissionStrategy::GraceInstantStream));
+        assert!(!available.contains(&AdmissionStrategy::GraceHoldStream));
+        assert!(available.contains(&AdmissionStrategy::EvictUserSameIpOldest));
+        assert!(available.contains(&AdmissionStrategy::EvictUserSameIpLatest));
+        assert!(available.contains(&AdmissionStrategy::EvictUserOldest));
+        assert!(available.contains(&AdmissionStrategy::EvictUserLatest));
     }
 
     #[test]
@@ -1227,16 +1227,13 @@ mod tests {
             "grace_hold_stream".to_string(),
         ]));
 
-        assert_eq!(
-            filter_disabled_grace_strategies(parsed, 0),
-            Some(vec![AdmissionStrategyDto::EvictUserSameIpOldest])
-        );
+        assert_eq!(filter_disabled_grace_strategies(parsed, 0), Some(vec![AdmissionStrategy::EvictUserSameIpOldest]));
     }
 
     #[test]
     fn add_admission_strategy_enforces_narrower_before_broader() {
         let current = vec!["evict_user_oldest".to_string()];
-        let new_tags = add_admission_strategy_tag(&current, "evict_user_same_ip_oldest");
+        let new_tags = add_admission_strategy_tag(&current, AdmissionStrategy::EvictUserSameIpOldest);
         assert_eq!(new_tags, vec!["evict_user_same_ip_oldest".to_string(), "evict_user_oldest".to_string()]);
     }
 

--- a/frontend/src/app/components/config/reverse_proxy_config_view.rs
+++ b/frontend/src/app/components/config/reverse_proxy_config_view.rs
@@ -315,6 +315,12 @@ fn move_admission_strategy_tag(current: &[String], index: usize, delta: isize) -
     if let Some(target_index) = index.checked_add_signed(delta) {
         if index < next.len() && target_index < next.len() {
             next.swap(index, target_index);
+            // Reject the move if it would create an invalid ordering (broader before narrower).
+            let strategy_dtos: Vec<AdmissionStrategyDto> =
+                next.iter().filter_map(|t| parse_admission_strategy_tag(t)).collect();
+            if !shared::model::is_valid_admission_strategy_order(&strategy_dtos) {
+                next.swap(index, target_index); // revert
+            }
         }
     }
     next

--- a/frontend/src/app/components/config/reverse_proxy_config_view.rs
+++ b/frontend/src/app/components/config/reverse_proxy_config_view.rs
@@ -1148,6 +1148,12 @@ mod tests {
     }
 
     #[test]
+    fn admission_strategy_tags_roundtrip_evict_user_latest() {
+        let tags = admission_strategy_tags(Some(&vec![AdmissionStrategyDto::EvictUserLatest])).unwrap_or_default();
+        assert_eq!(parse_admission_strategy_tags(Some(&tags)), Some(vec![AdmissionStrategyDto::EvictUserLatest]));
+    }
+
+    #[test]
     fn invalid_admission_strategy_tags_are_ignored() {
         let tags = vec!["evict_user_latest".to_string(), "not-a-strategy".to_string(), "evict_user_latest".to_string()];
         assert_eq!(parse_admission_strategy_tags(Some(&tags)), Some(vec![AdmissionStrategyDto::EvictUserLatest]));

--- a/shared/src/model/config/stream.rs
+++ b/shared/src/model/config/stream.rs
@@ -18,6 +18,10 @@ pub enum AdmissionStrategyDto {
     EvictUserSameIpOldest,
     #[serde(rename = "evict_user_same_ip_latest")]
     EvictUserSameIpLatest,
+    #[serde(rename = "evict_user_oldest")]
+    EvictUserOldest,
+    #[serde(rename = "evict_user_latest")]
+    EvictUserLatest,
     #[serde(rename = "grace_instant_stream")]
     GraceInstantStream,
     #[serde(rename = "grace_hold_stream")]
@@ -216,7 +220,7 @@ mod tests {
     fn test_valid_ordered_subset_accepted() {
         let mut dto = StreamConfigDto::default();
         dto.admission_strategies =
-            Some(vec![AdmissionStrategyDto::EvictUserSameIpOldest, AdmissionStrategyDto::GraceHoldStream]);
+            Some(vec![AdmissionStrategyDto::EvictUserOldest, AdmissionStrategyDto::GraceHoldStream]);
         assert!(dto.prepare().is_ok());
     }
 
@@ -235,6 +239,8 @@ mod tests {
         for s in [
             AdmissionStrategyDto::EvictUserSameIpOldest,
             AdmissionStrategyDto::EvictUserSameIpLatest,
+            AdmissionStrategyDto::EvictUserOldest,
+            AdmissionStrategyDto::EvictUserLatest,
             AdmissionStrategyDto::GraceInstantStream,
             AdmissionStrategyDto::GraceHoldStream,
         ] {

--- a/shared/src/model/config/stream.rs
+++ b/shared/src/model/config/stream.rs
@@ -243,6 +243,26 @@ mod tests {
     }
 
     #[test]
+    fn test_safe_ordering_same_ip_oldest_before_oldest_accepted() {
+        let mut dto = StreamConfigDto::default();
+        dto.admission_strategies = Some(vec![
+            AdmissionStrategyDto::EvictUserSameIpOldest,
+            AdmissionStrategyDto::EvictUserOldest,
+        ]);
+        assert!(dto.prepare().is_ok());
+    }
+
+    #[test]
+    fn test_safe_ordering_same_ip_latest_before_latest_accepted() {
+        let mut dto = StreamConfigDto::default();
+        dto.admission_strategies = Some(vec![
+            AdmissionStrategyDto::EvictUserSameIpLatest,
+            AdmissionStrategyDto::EvictUserLatest,
+        ]);
+        assert!(dto.prepare().is_ok());
+    }
+
+    #[test]
     fn test_grace_strategy_requires_positive_grace_period() {
         let mut dto = StreamConfigDto::default();
         dto.grace_period_millis = 0;

--- a/shared/src/model/config/stream.rs
+++ b/shared/src/model/config/stream.rs
@@ -176,20 +176,36 @@ fn validate_admission_strategies(strategies: &[AdmissionStrategyDto], grace_peri
         return Err("admission_strategies: grace strategies require grace_period_millis > 0".into());
     }
 
+    validate_admission_strategy_order(strategies)?;
+
+    Ok(())
+}
+
+pub fn is_valid_admission_strategy_order(strategies: &[AdmissionStrategyDto]) -> bool {
+    validate_admission_strategy_order(strategies).is_ok()
+}
+
+pub fn validate_admission_strategy_order(strategies: &[AdmissionStrategyDto]) -> Result<(), String> {
+    use AdmissionStrategyDto::*;
+
     fn strategy_index(strategies: &[AdmissionStrategyDto], strategy: AdmissionStrategyDto) -> Option<usize> {
         strategies.iter().position(|candidate| *candidate == strategy)
     }
 
-    for (broader, narrower) in [(EvictUserOldest, EvictUserSameIpOldest), (EvictUserLatest, EvictUserSameIpLatest)] {
-        if let (Some(broader_idx), Some(narrower_idx)) =
-            (strategy_index(strategies, broader), strategy_index(strategies, narrower))
-        {
-            if broader_idx < narrower_idx {
-                let broader_name = serde_json::to_string(&broader).unwrap_or_default().trim_matches('"').to_string();
-                let narrower_name = serde_json::to_string(&narrower).unwrap_or_default().trim_matches('"').to_string();
-                return Err(format!(
-                    "admission_strategies: {broader_name} must not appear before {narrower_name} because the later rule would be shadowed"
-                ));
+    for broader in [EvictUserOldest, EvictUserLatest] {
+        if let Some(broader_idx) = strategy_index(strategies, broader) {
+            for narrower in [EvictUserSameIpOldest, EvictUserSameIpLatest] {
+                if let Some(narrower_idx) = strategy_index(strategies, narrower) {
+                    if broader_idx < narrower_idx {
+                        let broader_name =
+                            serde_json::to_string(&broader).unwrap_or_default().trim_matches('"').to_string();
+                        let narrower_name =
+                            serde_json::to_string(&narrower).unwrap_or_default().trim_matches('"').to_string();
+                        return Err(format!(
+                            "admission_strategies: {broader_name} must not appear before {narrower_name} because the later rule would be shadowed"
+                        ));
+                    }
+                }
             }
         }
     }
@@ -289,11 +305,13 @@ mod tests {
     }
 
     #[test]
-    fn test_cross_order_pair_with_different_selection_policy_is_allowed() {
+    fn test_cross_order_pair_with_different_selection_policy_is_rejected() {
         let mut dto = StreamConfigDto::default();
         dto.admission_strategies =
             Some(vec![AdmissionStrategyDto::EvictUserOldest, AdmissionStrategyDto::EvictUserSameIpLatest]);
-        assert!(dto.prepare().is_ok());
+        let err = dto.prepare().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("shadowed"), "msg: {msg}");
     }
 
     #[test]

--- a/shared/src/model/config/stream.rs
+++ b/shared/src/model/config/stream.rs
@@ -13,7 +13,7 @@ const STREAM_QUEUE_SIZE: usize = 1024; // mpsc channel holding messages. with 81
 const MIN_SHARED_BURST_BUFFER_MB: u64 = 1;
 
 #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-pub enum AdmissionStrategyDto {
+pub enum AdmissionStrategy {
     #[serde(rename = "evict_user_same_ip_oldest")]
     EvictUserSameIpOldest,
     #[serde(rename = "evict_user_same_ip_latest")]
@@ -26,6 +26,12 @@ pub enum AdmissionStrategyDto {
     GraceInstantStream,
     #[serde(rename = "grace_hold_stream")]
     GraceHoldStream,
+}
+
+impl AdmissionStrategy {
+    pub fn is_grace(&self) -> bool { matches!(self, Self::GraceInstantStream | Self::GraceHoldStream) }
+
+    pub fn is_grace_hold(&self) -> bool { matches!(self, Self::GraceHoldStream) }
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Default, PartialEq)]
@@ -76,7 +82,7 @@ pub struct StreamConfigDto {
     #[serde(default = "default_shared_burst_buffer_mb", skip_serializing_if = "is_default_shared_burst_buffer_mb")]
     pub shared_burst_buffer_mb: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub admission_strategies: Option<Vec<AdmissionStrategyDto>>,
+    pub admission_strategies: Option<Vec<AdmissionStrategy>>,
 }
 
 impl Default for StreamConfigDto {
@@ -152,9 +158,9 @@ impl StreamConfigDto {
     }
 }
 
-fn validate_admission_strategies(strategies: &[AdmissionStrategyDto], grace_period_millis: u64) -> Result<(), String> {
+fn validate_admission_strategies(strategies: &[AdmissionStrategy], grace_period_millis: u64) -> Result<(), String> {
     use std::collections::HashSet;
-    use AdmissionStrategyDto::*;
+    use AdmissionStrategy::*;
 
     let mut seen = HashSet::new();
     for s in strategies {
@@ -181,14 +187,14 @@ fn validate_admission_strategies(strategies: &[AdmissionStrategyDto], grace_peri
     Ok(())
 }
 
-pub fn is_valid_admission_strategy_order(strategies: &[AdmissionStrategyDto]) -> bool {
+pub fn is_valid_admission_strategy_order(strategies: &[AdmissionStrategy]) -> bool {
     validate_admission_strategy_order(strategies).is_ok()
 }
 
-pub fn validate_admission_strategy_order(strategies: &[AdmissionStrategyDto]) -> Result<(), String> {
-    use AdmissionStrategyDto::*;
+pub fn validate_admission_strategy_order(strategies: &[AdmissionStrategy]) -> Result<(), String> {
+    use AdmissionStrategy::*;
 
-    fn strategy_index(strategies: &[AdmissionStrategyDto], strategy: AdmissionStrategyDto) -> Option<usize> {
+    fn strategy_index(strategies: &[AdmissionStrategy], strategy: AdmissionStrategy) -> Option<usize> {
         strategies.iter().position(|candidate| *candidate == strategy)
     }
 
@@ -234,7 +240,7 @@ mod tests {
     fn test_duplicate_rejected() {
         let mut dto = StreamConfigDto::default();
         dto.admission_strategies =
-            Some(vec![AdmissionStrategyDto::EvictUserSameIpOldest, AdmissionStrategyDto::EvictUserSameIpOldest]);
+            Some(vec![AdmissionStrategy::EvictUserSameIpOldest, AdmissionStrategy::EvictUserSameIpOldest]);
         let err = dto.prepare().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("Duplicate admission strategy"), "msg: {msg}");
@@ -244,7 +250,7 @@ mod tests {
     fn test_mutually_exclusive_grace_rejected() {
         let mut dto = StreamConfigDto::default();
         dto.admission_strategies =
-            Some(vec![AdmissionStrategyDto::GraceInstantStream, AdmissionStrategyDto::GraceHoldStream]);
+            Some(vec![AdmissionStrategy::GraceInstantStream, AdmissionStrategy::GraceHoldStream]);
         let err = dto.prepare().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("mutually exclusive"), "msg: {msg}");
@@ -253,8 +259,7 @@ mod tests {
     #[test]
     fn test_valid_ordered_subset_accepted() {
         let mut dto = StreamConfigDto::default();
-        dto.admission_strategies =
-            Some(vec![AdmissionStrategyDto::EvictUserOldest, AdmissionStrategyDto::GraceHoldStream]);
+        dto.admission_strategies = Some(vec![AdmissionStrategy::EvictUserOldest, AdmissionStrategy::GraceHoldStream]);
         assert!(dto.prepare().is_ok());
     }
 
@@ -262,7 +267,7 @@ mod tests {
     fn test_safe_ordering_same_ip_oldest_before_oldest_accepted() {
         let mut dto = StreamConfigDto::default();
         dto.admission_strategies =
-            Some(vec![AdmissionStrategyDto::EvictUserSameIpOldest, AdmissionStrategyDto::EvictUserOldest]);
+            Some(vec![AdmissionStrategy::EvictUserSameIpOldest, AdmissionStrategy::EvictUserOldest]);
         assert!(dto.prepare().is_ok());
     }
 
@@ -270,7 +275,7 @@ mod tests {
     fn test_safe_ordering_same_ip_latest_before_latest_accepted() {
         let mut dto = StreamConfigDto::default();
         dto.admission_strategies =
-            Some(vec![AdmissionStrategyDto::EvictUserSameIpLatest, AdmissionStrategyDto::EvictUserLatest]);
+            Some(vec![AdmissionStrategy::EvictUserSameIpLatest, AdmissionStrategy::EvictUserLatest]);
         assert!(dto.prepare().is_ok());
     }
 
@@ -278,7 +283,7 @@ mod tests {
     fn test_grace_strategy_requires_positive_grace_period() {
         let mut dto = StreamConfigDto::default();
         dto.grace_period_millis = 0;
-        dto.admission_strategies = Some(vec![AdmissionStrategyDto::GraceHoldStream]);
+        dto.admission_strategies = Some(vec![AdmissionStrategy::GraceHoldStream]);
         let err = dto.prepare().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("grace_period_millis"), "msg: {msg}");
@@ -288,7 +293,7 @@ mod tests {
     fn test_shadowed_same_ip_oldest_order_rejected() {
         let mut dto = StreamConfigDto::default();
         dto.admission_strategies =
-            Some(vec![AdmissionStrategyDto::EvictUserOldest, AdmissionStrategyDto::EvictUserSameIpOldest]);
+            Some(vec![AdmissionStrategy::EvictUserOldest, AdmissionStrategy::EvictUserSameIpOldest]);
         let err = dto.prepare().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("shadowed"), "msg: {msg}");
@@ -298,7 +303,7 @@ mod tests {
     fn test_shadowed_same_ip_latest_order_rejected() {
         let mut dto = StreamConfigDto::default();
         dto.admission_strategies =
-            Some(vec![AdmissionStrategyDto::EvictUserLatest, AdmissionStrategyDto::EvictUserSameIpLatest]);
+            Some(vec![AdmissionStrategy::EvictUserLatest, AdmissionStrategy::EvictUserSameIpLatest]);
         let err = dto.prepare().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("shadowed"), "msg: {msg}");
@@ -308,7 +313,7 @@ mod tests {
     fn test_cross_order_pair_with_different_selection_policy_is_rejected() {
         let mut dto = StreamConfigDto::default();
         dto.admission_strategies =
-            Some(vec![AdmissionStrategyDto::EvictUserOldest, AdmissionStrategyDto::EvictUserSameIpLatest]);
+            Some(vec![AdmissionStrategy::EvictUserOldest, AdmissionStrategy::EvictUserSameIpLatest]);
         let err = dto.prepare().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("shadowed"), "msg: {msg}");
@@ -317,12 +322,12 @@ mod tests {
     #[test]
     fn test_single_strategy_accepted() {
         for s in [
-            AdmissionStrategyDto::EvictUserSameIpOldest,
-            AdmissionStrategyDto::EvictUserSameIpLatest,
-            AdmissionStrategyDto::EvictUserOldest,
-            AdmissionStrategyDto::EvictUserLatest,
-            AdmissionStrategyDto::GraceInstantStream,
-            AdmissionStrategyDto::GraceHoldStream,
+            AdmissionStrategy::EvictUserSameIpOldest,
+            AdmissionStrategy::EvictUserSameIpLatest,
+            AdmissionStrategy::EvictUserOldest,
+            AdmissionStrategy::EvictUserLatest,
+            AdmissionStrategy::GraceInstantStream,
+            AdmissionStrategy::GraceHoldStream,
         ] {
             let mut dto = StreamConfigDto::default();
             dto.admission_strategies = Some(vec![s]);
@@ -333,7 +338,7 @@ mod tests {
     #[test]
     fn test_is_empty_with_strategies() {
         let mut dto = StreamConfigDto::default();
-        dto.admission_strategies = Some(vec![AdmissionStrategyDto::GraceInstantStream]);
+        dto.admission_strategies = Some(vec![AdmissionStrategy::GraceInstantStream]);
         assert!(!dto.is_empty());
     }
 

--- a/shared/src/model/config/stream.rs
+++ b/shared/src/model/config/stream.rs
@@ -245,20 +245,16 @@ mod tests {
     #[test]
     fn test_safe_ordering_same_ip_oldest_before_oldest_accepted() {
         let mut dto = StreamConfigDto::default();
-        dto.admission_strategies = Some(vec![
-            AdmissionStrategyDto::EvictUserSameIpOldest,
-            AdmissionStrategyDto::EvictUserOldest,
-        ]);
+        dto.admission_strategies =
+            Some(vec![AdmissionStrategyDto::EvictUserSameIpOldest, AdmissionStrategyDto::EvictUserOldest]);
         assert!(dto.prepare().is_ok());
     }
 
     #[test]
     fn test_safe_ordering_same_ip_latest_before_latest_accepted() {
         let mut dto = StreamConfigDto::default();
-        dto.admission_strategies = Some(vec![
-            AdmissionStrategyDto::EvictUserSameIpLatest,
-            AdmissionStrategyDto::EvictUserLatest,
-        ]);
+        dto.admission_strategies =
+            Some(vec![AdmissionStrategyDto::EvictUserSameIpLatest, AdmissionStrategyDto::EvictUserLatest]);
         assert!(dto.prepare().is_ok());
     }
 

--- a/shared/src/model/config/stream.rs
+++ b/shared/src/model/config/stream.rs
@@ -176,6 +176,24 @@ fn validate_admission_strategies(strategies: &[AdmissionStrategyDto], grace_peri
         return Err("admission_strategies: grace strategies require grace_period_millis > 0".into());
     }
 
+    fn strategy_index(strategies: &[AdmissionStrategyDto], strategy: AdmissionStrategyDto) -> Option<usize> {
+        strategies.iter().position(|candidate| *candidate == strategy)
+    }
+
+    for (broader, narrower) in [(EvictUserOldest, EvictUserSameIpOldest), (EvictUserLatest, EvictUserSameIpLatest)] {
+        if let (Some(broader_idx), Some(narrower_idx)) =
+            (strategy_index(strategies, broader), strategy_index(strategies, narrower))
+        {
+            if broader_idx < narrower_idx {
+                let broader_name = serde_json::to_string(&broader).unwrap_or_default().trim_matches('"').to_string();
+                let narrower_name = serde_json::to_string(&narrower).unwrap_or_default().trim_matches('"').to_string();
+                return Err(format!(
+                    "admission_strategies: {broader_name} must not appear before {narrower_name} because the later rule would be shadowed"
+                ));
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -232,6 +250,34 @@ mod tests {
         let err = dto.prepare().unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("grace_period_millis"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_shadowed_same_ip_oldest_order_rejected() {
+        let mut dto = StreamConfigDto::default();
+        dto.admission_strategies =
+            Some(vec![AdmissionStrategyDto::EvictUserOldest, AdmissionStrategyDto::EvictUserSameIpOldest]);
+        let err = dto.prepare().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("shadowed"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_shadowed_same_ip_latest_order_rejected() {
+        let mut dto = StreamConfigDto::default();
+        dto.admission_strategies =
+            Some(vec![AdmissionStrategyDto::EvictUserLatest, AdmissionStrategyDto::EvictUserSameIpLatest]);
+        let err = dto.prepare().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("shadowed"), "msg: {msg}");
+    }
+
+    #[test]
+    fn test_cross_order_pair_with_different_selection_policy_is_allowed() {
+        let mut dto = StreamConfigDto::default();
+        dto.admission_strategies =
+            Some(vec![AdmissionStrategyDto::EvictUserOldest, AdmissionStrategyDto::EvictUserSameIpLatest]);
+        assert!(dto.prepare().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Added new connection admission rules

- evict_user_lastest
- evict_user_oldest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User-wide eviction strategies (evict user oldest/latest); session-activation/reservation flow for soft slots; provider URL failover policy; Web UI landing-page and CVD-friendly theme; opt-in runtime config startup dump; new UI labels for admission strategies.

* **Improvements**
  * Admission-strategy ordering validation to prevent shadowing; clarified session vs socket counting (HLS/catchup vs TS/VOD/local); clearer admission ordering/behavior; more precise typed error reporting.

* **Documentation**
  * Expanded connection-handling and reverse-proxy docs with examples, ordering guidance, and configuration notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->