### PR TITLE
Fix EPG programme merging across XMLTV sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,13 @@ backend/Cargo.lock
 !README.md
 !CHANGELOG.md
 !CONTRIBUTING.md
+!epg_merge_patch.md
 
 # Ignore ai documentation files
 .c[lor][adu]*
 .dual-graph/
 .dual-graph-context/
+
+# Local analysis outputs
+epg_mapping_analysis.txt
+missing.txt

--- a/backend/src/api/endpoints/v1_api_playlist.rs
+++ b/backend/src/api/endpoints/v1_api_playlist.rs
@@ -1,27 +1,38 @@
 use crate::api::api_utils::resource_response;
-use crate::{api::{
-    api_utils::{create_api_proxy_user, json_or_bin_response},
-    endpoints::{
-        api_playlist_utils::{get_playlist_for_custom_provider, get_playlist_for_input, get_playlist_for_target},
-        extract_accept_header::ExtractAcceptHeader,
-        xmltv_api::{rewrite_epg_channel_resource_url, serve_epg_web_ui, stream_epg_api},
-        xtream_api::xtream_get_stream_info_response,
+use crate::{
+    api::{
+        api_utils::{create_api_proxy_user, json_or_bin_response},
+        endpoints::{
+            api_playlist_utils::{get_playlist_for_custom_provider, get_playlist_for_input, get_playlist_for_target},
+            extract_accept_header::ExtractAcceptHeader,
+            xmltv_api::{rewrite_epg_channel_resource_url, serve_epg_web_ui, stream_epg_api},
+            xtream_api::xtream_get_stream_info_response,
+        },
+        model::AppState,
     },
-    model::AppState,
-}, auth::{create_access_token, permission_layer}, model::{parse_xmltv_for_web_ui_from_file, parse_xmltv_for_web_ui_from_url, AppConfig, ConfigInput, ConfigInputFlags, ConfigInputOptions}, repository::xtream_get_item_for_stream_id, utils::{epg::get_input_raw_epg_file_path, file_exists_async}};
+    auth::{create_access_token, permission_layer},
+    model::{
+        AppConfig, ConfigInput, ConfigInputFlags, ConfigInputOptions, parse_xmltv_for_web_ui_from_file,
+        parse_xmltv_for_web_ui_from_url,
+    },
+    repository::xtream_get_item_for_stream_id,
+    utils::{epg::get_input_raw_epg_file_path, file_exists_async},
+};
 use axum::{response::IntoResponse, Router};
 use log::{debug, error};
 use serde_json::json;
 use shared::utils::deobfuscate_text;
 use shared::{
     model::{
-        permission::Permission, EpgChannel, EpgProgramme,
-        InputType, PlaylistEpgRequest, PlaylistRequest, PlaylistUrlResolveRequest, ProxyType, TargetType, UiPlaylistItem,
-        XtreamCluster,
+        EpgChannel, EpgProgramme, InputType, PlaylistEpgRequest, PlaylistRequest, PlaylistUrlResolveRequest, ProxyType,
+        TargetType, UiPlaylistItem, XtreamCluster, permission::Permission,
     },
-    utils::{concat_path_leading_slash, sanitize_sensitive_info, Internable},
+    utils::{Internable, concat_path_leading_slash, sanitize_sensitive_info},
 };
-use std::{collections::{HashMap, HashSet}, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 use url::Url;
 
 fn create_config_input_for_m3u(url: &str) -> ConfigInput {
@@ -90,9 +101,7 @@ fn resolve_provider_url_for_request(app_config: &AppConfig, playlist_request: &P
             .get_target_by_id(*target_id)
             .and_then(|target| app_config.get_inputs_for_target(&target.name))
             .and_then(|inputs| {
-                let mut matches = inputs
-                    .into_iter()
-                    .filter(|input| input.get_resolve_provider(url).is_some());
+                let mut matches = inputs.into_iter().filter(|input| input.get_resolve_provider(url).is_some());
                 let first = matches.next()?;
                 if matches.next().is_some() {
                     return None;
@@ -111,12 +120,7 @@ fn build_playlist_webplayer_url(
     virtual_id: u32,
     cluster: XtreamCluster,
 ) -> String {
-    format!(
-        "{base_url}/token/{access_token}/{}/{}/{}",
-        target_id,
-        cluster.as_stream_type(),
-        virtual_id
-    )
+    format!("{base_url}/token/{access_token}/{}/{}/{}", target_id, cluster.as_stream_type(), virtual_id)
 }
 
 #[derive(Hash, Eq, PartialEq)]
@@ -127,10 +131,7 @@ struct WebUiProgrammeKey {
 
 impl From<&EpgProgramme> for WebUiProgrammeKey {
     fn from(programme: &EpgProgramme) -> Self {
-        Self {
-            start: programme.start,
-            stop: programme.stop,
-        }
+        Self { start: programme.start, stop: programme.stop }
     }
 }
 
@@ -138,6 +139,22 @@ struct WebUiChannelAcc {
     priority: i16,
     channel: EpgChannel,
     programmes: HashSet<WebUiProgrammeKey>,
+}
+
+fn merge_missing_web_ui_programmes<I>(
+    channel: &mut EpgChannel,
+    programmes: &mut HashSet<WebUiProgrammeKey>,
+    incoming: I,
+) where
+    I: IntoIterator<Item = EpgProgramme>,
+{
+    for programme in incoming {
+        let key = WebUiProgrammeKey::from(&programme);
+        if programmes.insert(key) {
+            channel.programmes.push(programme);
+        }
+    }
+    channel.programmes.sort_by_key(|programme| programme.start);
 }
 
 fn merge_epg_channels(mut channels_by_source: Vec<(i16, Vec<EpgChannel>)>) -> Vec<EpgChannel> {
@@ -150,37 +167,18 @@ fn merge_epg_channels(mut channels_by_source: Vec<(i16, Vec<EpgChannel>)>) -> Ve
                 std::collections::hash_map::Entry::Occupied(mut entry) => {
                     let acc = entry.get_mut();
                     if priority < acc.priority {
-                        let programmes = channel
-                            .programmes
-                            .iter()
-                            .map(WebUiProgrammeKey::from)
-                            .collect::<HashSet<_>>();
-                        *acc = WebUiChannelAcc {
-                            priority,
-                            channel,
-                            programmes,
-                        };
-                    } else if priority == acc.priority {
-                        for programme in channel.programmes {
-                            let key = WebUiProgrammeKey::from(&programme);
-                            if acc.programmes.insert(key) {
-                                acc.channel.programmes.push(programme);
-                            }
-                        }
-                        acc.channel.programmes.sort_by_key(|programme| programme.start);
+                        let previous_programmes = std::mem::replace(&mut acc.channel, channel).programmes;
+                        acc.priority = priority;
+                        acc.programmes =
+                            acc.channel.programmes.iter().map(WebUiProgrammeKey::from).collect::<HashSet<_>>();
+                        merge_missing_web_ui_programmes(&mut acc.channel, &mut acc.programmes, previous_programmes);
+                    } else {
+                        merge_missing_web_ui_programmes(&mut acc.channel, &mut acc.programmes, channel.programmes);
                     }
                 }
                 std::collections::hash_map::Entry::Vacant(entry) => {
-                    let programmes = channel
-                        .programmes
-                        .iter()
-                        .map(WebUiProgrammeKey::from)
-                        .collect::<HashSet<_>>();
-                    entry.insert(WebUiChannelAcc {
-                        priority,
-                        channel,
-                        programmes,
-                    });
+                    let programmes = channel.programmes.iter().map(WebUiProgrammeKey::from).collect::<HashSet<_>>();
+                    entry.insert(WebUiChannelAcc { priority, channel, programmes });
                 }
             }
         }
@@ -200,25 +198,25 @@ async fn load_epg_channels_for_input(
     };
 
     let storage_dir = app_state.app_config.config.load().storage_dir.clone();
-        let mut channels_by_source = Vec::new();
-        let mut failed_sources = 0usize;
+    let mut channels_by_source = Vec::new();
+    let mut failed_sources = 0usize;
 
-        for epg_source in &epg_config.sources {
-            let resolved_url = resolve_provider_url_with_input(input, &epg_source.url);
-            let raw_epg_path = match get_input_raw_epg_file_path(&resolved_url, input, &storage_dir).await {
-                Ok(path) => path,
-                Err(err) => {
-                    debug!(
-                        "Skipping EPG source {}: {}",
-                        sanitize_sensitive_info(resolved_url.as_str()),
-                        sanitize_sensitive_info(&err.to_string())
-                    );
-                    failed_sources += 1;
-                    continue;
-                }
-            };
+    for epg_source in &epg_config.sources {
+        let resolved_url = resolve_provider_url_with_input(input, &epg_source.url);
+        let raw_epg_path = match get_input_raw_epg_file_path(&resolved_url, input, &storage_dir).await {
+            Ok(path) => path,
+            Err(err) => {
+                debug!(
+                    "Skipping EPG source {}: {}",
+                    sanitize_sensitive_info(resolved_url.as_str()),
+                    sanitize_sensitive_info(&err.to_string())
+                );
+                failed_sources += 1;
+                continue;
+            }
+        };
 
-            let source_channels = if file_exists_async(&raw_epg_path).await {
+        let source_channels = if file_exists_async(&raw_epg_path).await {
             match parse_xmltv_for_web_ui_from_file(&raw_epg_path).await {
                 Ok(ch) => ch,
                 Err(file_err) => {
@@ -229,9 +227,11 @@ async fn load_epg_channels_for_input(
                     match parse_xmltv_for_web_ui_from_url(app_state, &resolved_url).await {
                         Ok(ch) => ch,
                         Err(url_err) => {
-                            debug!("EPG url also failed {}: {}",
+                            debug!(
+                                "EPG url also failed {}: {}",
                                 sanitize_sensitive_info(resolved_url.as_str()),
-                                sanitize_sensitive_info(&url_err.to_string()));
+                                sanitize_sensitive_info(&url_err.to_string())
+                            );
                             failed_sources += 1;
                             continue;
                         }
@@ -242,9 +242,11 @@ async fn load_epg_channels_for_input(
             match parse_xmltv_for_web_ui_from_url(app_state, &resolved_url).await {
                 Ok(ch) => ch,
                 Err(err) => {
-                    debug!("Skipping EPG url {}: {}",
+                    debug!(
+                        "Skipping EPG url {}: {}",
                         sanitize_sensitive_info(resolved_url.as_str()),
-                        sanitize_sensitive_info(&err.to_string()));
+                        sanitize_sensitive_info(&err.to_string())
+                    );
                     failed_sources += 1;
                     continue;
                 }
@@ -312,26 +314,20 @@ async fn playlist_content(
             cluster,
             accept.as_deref(),
         )
-            .await
-            .into_response(),
+        .await
+        .into_response(),
         PlaylistRequest::Input(input_name) => get_playlist_for_input(
             app_state.app_config.get_input_by_name(&input_name.intern()).as_ref(),
             app_state,
             cluster,
             accept.as_deref(),
         )
-            .await
-            .into_response(),
+        .await
+        .into_response(),
         PlaylistRequest::CustomXtream(xtream) => match Url::parse(&xtream.url) {
             Ok(parsed) if parsed.scheme() == "http" || parsed.scheme() == "https" => {
                 let input = Arc::new(create_config_input_for_xtream(&xtream.username, &xtream.password, &xtream.url));
-                get_playlist_for_custom_provider(
-                    client.as_ref(),
-                    Some(&input),
-                    app_state,
-                    cluster,
-                    accept.as_deref(),
-                )
+                get_playlist_for_custom_provider(client.as_ref(), Some(&input), app_state, cluster, accept.as_deref())
                     .await
                     .into_response()
             }
@@ -344,13 +340,7 @@ async fn playlist_content(
         PlaylistRequest::CustomM3u(m3u) => match Url::parse(&m3u.url) {
             Ok(parsed) if parsed.scheme() == "http" || parsed.scheme() == "https" => {
                 let input = Arc::new(create_config_input_for_m3u(&m3u.url));
-                get_playlist_for_custom_provider(
-                    client.as_ref(),
-                    Some(&input),
-                    app_state,
-                    cluster,
-                    accept.as_deref(),
-                )
+                get_playlist_for_custom_provider(client.as_ref(), Some(&input), app_state, cluster, accept.as_deref())
                     .await
                     .into_response()
             }
@@ -397,8 +387,8 @@ async fn playlist_series_info(
                         &virtual_id,
                         XtreamCluster::Series,
                     )
-                        .await
-                        .into_response();
+                    .await
+                    .into_response();
                 }
             }
         }
@@ -460,7 +450,8 @@ async fn playlist_epg(
                 match load_epg_channels_for_input(&app_state, input.as_ref()).await {
                     Ok(Some(epg)) => {
                         let config = app_state.app_config.config.load();
-                        let web_ui_path = config.web_ui.as_ref().and_then(|w| w.path.as_ref()).map_or("", String::as_str);
+                        let web_ui_path =
+                            config.web_ui.as_ref().and_then(|w| w.path.as_ref()).map_or("", String::as_str);
                         let resource_url = concat_path_leading_slash(web_ui_path, "api/v1/playlist/resource");
                         let encrypt_secret = app_state.get_encrypt_secret();
                         let epg = epg
@@ -471,7 +462,11 @@ async fn playlist_epg(
                     }
                     Ok(None) => return axum::http::StatusCode::NO_CONTENT.into_response(),
                     Err(err) => {
-                        error!("Failed to load input EPG for '{}': {}", input.name, sanitize_sensitive_info(err.to_string().as_str()));
+                        error!(
+                            "Failed to load input EPG for '{}': {}",
+                            input.name,
+                            sanitize_sensitive_info(err.to_string().as_str())
+                        );
                         return (
                             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                             axum::Json(serde_json::json!({"error": "Failed to load EPG"})),
@@ -481,29 +476,27 @@ async fn playlist_epg(
                 }
             }
         }
-        PlaylistEpgRequest::Custom(url) => {
-            match parse_xmltv_for_web_ui_from_url(&app_state, &url).await {
-                Ok(epg) => {
-                    let config = app_state.app_config.config.load();
-                    let web_ui_path = config.web_ui.as_ref().and_then(|w| w.path.as_ref()).map_or("", String::as_str);
-                    let resource_url = concat_path_leading_slash(web_ui_path, "api/v1/playlist/resource");
-                    let encrypt_secret = app_state.get_encrypt_secret();
-                    let epg = epg
-                        .into_iter()
-                        .map(|channel| rewrite_epg_channel_resource_url(&encrypt_secret, &resource_url, channel))
-                        .collect::<Vec<_>>();
-                    return json_or_bin_response(accept.as_deref(), &epg).into_response();
-                }
-                Err(err) => {
-                    error!("Failed to load custom EPG: {}", sanitize_sensitive_info(err.to_string().as_str()));
-                    return (
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        axum::Json(serde_json::json!({"error": "Failed to load EPG"})),
-                    )
-                        .into_response();
-                }
+        PlaylistEpgRequest::Custom(url) => match parse_xmltv_for_web_ui_from_url(&app_state, &url).await {
+            Ok(epg) => {
+                let config = app_state.app_config.config.load();
+                let web_ui_path = config.web_ui.as_ref().and_then(|w| w.path.as_ref()).map_or("", String::as_str);
+                let resource_url = concat_path_leading_slash(web_ui_path, "api/v1/playlist/resource");
+                let encrypt_secret = app_state.get_encrypt_secret();
+                let epg = epg
+                    .into_iter()
+                    .map(|channel| rewrite_epg_channel_resource_url(&encrypt_secret, &resource_url, channel))
+                    .collect::<Vec<_>>();
+                return json_or_bin_response(accept.as_deref(), &epg).into_response();
             }
-        }
+            Err(err) => {
+                error!("Failed to load custom EPG: {}", sanitize_sensitive_info(err.to_string().as_str()));
+                return (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    axum::Json(serde_json::json!({"error": "Failed to load EPG"})),
+                )
+                    .into_response();
+            }
+        },
     }
     axum::http::StatusCode::NO_CONTENT.into_response()
 }
@@ -527,13 +520,7 @@ async fn playlist_resolve_url(
 ) -> impl IntoResponse + Send {
     match request {
         PlaylistUrlResolveRequest::Webplayer { target_id, virtual_id, cluster } => {
-            playlist_webplayer(
-                axum::extract::State(app_state),
-                target_id,
-                virtual_id,
-                cluster,
-            )
-                .into_response()
+            playlist_webplayer(axum::extract::State(app_state), target_id, virtual_id, cluster).into_response()
         }
         PlaylistUrlResolveRequest::Provider { playlist_request, url } => {
             resolve_provider_url_for_request(&app_state.app_config, &playlist_request, &url).into_response()
@@ -554,9 +541,7 @@ pub fn v1_api_playlist_register_protected(router: Router<Arc<AppState>>) -> axum
         .route("/playlist/series/episode/{virtual_id}", axum::routing::post(playlist_episode_item))
 }
 
-pub fn v1_api_playlist_register_public(
-    router: Router<Arc<AppState>>,
-) -> axum::Router<Arc<AppState>> {
+pub fn v1_api_playlist_register_public(router: Router<Arc<AppState>>) -> axum::Router<Arc<AppState>> {
     router.route("/playlist/resource/{resource}", axum::routing::get(playlist_resource))
 }
 
@@ -582,11 +567,7 @@ pub fn v1_api_playlist_register_with_permissions(
         .route("/epg/stream", axum::routing::post(stream_epg_api))
         .layer(permission_layer!(app_state, Permission::EpgRead));
 
-    router.nest("/playlist",
-                read_routes
-                    .merge(write_routes)
-                    .merge(epg_routes),
-    )
+    router.nest("/playlist", read_routes.merge(write_routes).merge(epg_routes))
 }
 
 async fn playlist_episode_item(
@@ -618,28 +599,34 @@ mod tests {
             ActiveProviderManager, ActiveUserManager, AppState, ConnectionManager, EventManager, MetadataUpdateManager,
             PlaylistStorageState, SharedStreamManager,
         },
-        model::{AppConfig, Config, ConfigInput, ConfigProvider, ConfigSource, ConfigTarget, SourcesConfig, StreamHistoryConfig},
-        utils::epg::get_input_raw_epg_file_path,
+        model::{
+            AppConfig, Config, ConfigInput, ConfigProvider, ConfigSource, ConfigTarget, SourcesConfig,
+            StreamHistoryConfig,
+        },
         utils::GeoIp,
+        utils::epg::get_input_raw_epg_file_path,
     };
     use arc_swap::{ArcSwap, ArcSwapOption};
     use axum::{
+        Router,
         body::Body,
         http::{Request, StatusCode},
-        Router,
     };
+    use chrono::Utc;
     use shared::foundation::Filter;
+    use shared::model::ProcessingOrder;
     use shared::{
-        model::{ConfigPaths, ConfigProviderDto, EpgChannel, EpgConfigDto, EpgProgramme, EpgSourceDto, PlaylistRequest, XtreamCluster},
+        model::{
+            ConfigPaths, ConfigProviderDto, EpgChannel, EpgConfigDto, EpgProgramme, EpgSourceDto, PlaylistRequest,
+            XtreamCluster,
+        },
         utils::Internable,
     };
     use std::sync::Arc;
-    use chrono::Utc;
     use tempfile::tempdir;
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
     use tower::ServiceExt;
-    use shared::model::ProcessingOrder;
 
     /// Generate an XMLTV datetime string in the format `YYYYMMDDHHmmss +0000`
     /// offset by `hours_from_now` hours from the current time.
@@ -822,7 +809,8 @@ mod tests {
         let source = ConfigSource { inputs: vec![Arc::clone(&input.name)], targets: vec![] };
         let app_config = test_app_config(input, source);
         let original = "provider://unknown/live/user/pass/1359.ts";
-        let resolved = resolve_provider_url_for_request(&app_config, &PlaylistRequest::Input("input".to_string()), original);
+        let resolved =
+            resolve_provider_url_for_request(&app_config, &PlaylistRequest::Input("input".to_string()), original);
 
         assert_eq!(resolved, original);
     }
@@ -907,10 +895,8 @@ mod tests {
             watch: None,
             use_memory_cache: false,
         });
-        let source = ConfigSource {
-            inputs: vec![Arc::clone(&input_a.name), Arc::clone(&input_b.name)],
-            targets: vec![target],
-        };
+        let source =
+            ConfigSource { inputs: vec![Arc::clone(&input_a.name), Arc::clone(&input_b.name)], targets: vec![target] };
         let sources = SourcesConfig {
             batch_files: vec![],
             provider: vec![],
@@ -953,7 +939,8 @@ mod tests {
     #[test]
     fn build_playlist_webplayer_url_uses_cluster_stream_type() {
         let live = super::build_playlist_webplayer_url("http://player.example", "token123", 1, 42, XtreamCluster::Live);
-        let movie = super::build_playlist_webplayer_url("http://player.example", "token123", 1, 42, XtreamCluster::Video);
+        let movie =
+            super::build_playlist_webplayer_url("http://player.example", "token123", 1, 42, XtreamCluster::Video);
         let series =
             super::build_playlist_webplayer_url("http://player.example", "token123", 1, 42, XtreamCluster::Series);
 
@@ -963,30 +950,18 @@ mod tests {
     }
 
     #[test]
-    fn merge_epg_channels_prefers_higher_priority_source_and_merges_equal_priority_programmes() {
+    fn merge_epg_channels_prefers_higher_priority_metadata_and_merges_all_programmes() {
         let low_priority = EpgChannel {
             id: "demo.channel".intern(),
             title: Some("Low".intern()),
             icon: Some("http://low/icon.png".intern()),
-            programmes: vec![EpgProgramme::new_all(
-                10,
-                20,
-                "demo.channel".intern(),
-                Some("Low Show".intern()),
-                None,
-            )],
+            programmes: vec![EpgProgramme::new_all(10, 20, "demo.channel".intern(), Some("Low Show".intern()), None)],
         };
         let high_priority = EpgChannel {
             id: "demo.channel".intern(),
             title: Some("High".intern()),
             icon: Some("http://high/icon.png".intern()),
-            programmes: vec![EpgProgramme::new_all(
-                30,
-                40,
-                "demo.channel".intern(),
-                Some("High Show".intern()),
-                None,
-            )],
+            programmes: vec![EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("High Show".intern()), None)],
         };
         let same_priority = EpgChannel {
             id: "demo.channel".intern(),
@@ -998,19 +973,19 @@ mod tests {
             ],
         };
 
-        let channels = super::merge_epg_channels(vec![(10, vec![low_priority]), (0, vec![high_priority]), (0, vec![same_priority])]);
+        let channels = super::merge_epg_channels(vec![
+            (10, vec![low_priority]),
+            (0, vec![high_priority]),
+            (0, vec![same_priority]),
+        ]);
 
         assert_eq!(channels.len(), 1);
         assert_eq!(channels[0].title.as_deref(), Some("High"));
         assert_eq!(channels[0].icon.as_deref(), Some("http://high/icon.png"));
-        assert_eq!(channels[0].programmes.len(), 2);
+        assert_eq!(channels[0].programmes.len(), 3);
         assert_eq!(
-            channels[0]
-                .programmes
-                .iter()
-                .map(|programme| (programme.start, programme.stop))
-                .collect::<Vec<_>>(),
-            vec![(30, 40), (50, 60)],
+            channels[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
+            vec![(10, 20), (30, 40), (50, 60)],
         );
     }
 
@@ -1042,10 +1017,7 @@ mod tests {
             provider_configs: Some(vec![Arc::new(provider)]),
             ..Default::default()
         });
-        let source = ConfigSource {
-            inputs: vec![Arc::clone(&input.name)],
-            targets: vec![],
-        };
+        let source = ConfigSource { inputs: vec![Arc::clone(&input.name)], targets: vec![] };
         let app_config = test_app_config(input.clone(), source);
         app_config.config.store(Arc::new(Config {
             storage_dir: temp_dir.path().to_string_lossy().to_string(),
@@ -1056,8 +1028,8 @@ mod tests {
             input.as_ref(),
             temp_dir.path().to_string_lossy().as_ref(),
         )
-            .await
-            .expect("epg path");
+        .await
+        .expect("epg path");
         if let Some(parent) = raw_epg_path.parent() {
             tokio::fs::create_dir_all(parent).await.expect("epg dir");
         }
@@ -1077,22 +1049,17 @@ mod tests {
 </tv>"#
             ),
         )
-            .await
-            .expect("write epg");
+        .await
+        .expect("write epg");
 
         let app_state = test_app_state(Arc::new(app_config));
-        let channels = super::load_epg_channels_for_input(&app_state, input.as_ref())
-            .await
-            .expect("load epg")
-            .expect("channels");
+        let channels =
+            super::load_epg_channels_for_input(&app_state, input.as_ref()).await.expect("load epg").expect("channels");
 
         assert_eq!(channels.len(), 1);
         assert_eq!(channels[0].id.as_ref(), "demo.channel");
         assert_eq!(channels[0].programmes.len(), 1);
-        assert_eq!(
-            channels[0].programmes[0].title.as_ref().map(std::convert::AsRef::as_ref),
-            Some("Morning Show")
-        );
+        assert_eq!(channels[0].programmes[0].title.as_ref().map(std::convert::AsRef::as_ref), Some("Morning Show"));
     }
 
     #[tokio::test]
@@ -1123,10 +1090,7 @@ mod tests {
             provider_configs: Some(vec![Arc::new(provider)]),
             ..Default::default()
         });
-        let source = ConfigSource {
-            inputs: vec![Arc::clone(&input.name)],
-            targets: vec![],
-        };
+        let source = ConfigSource { inputs: vec![Arc::clone(&input.name)], targets: vec![] };
         let app_config = test_app_config(input.clone(), source);
         app_config.config.store(Arc::new(Config {
             storage_dir: temp_dir.path().to_string_lossy().to_string(),
@@ -1137,8 +1101,8 @@ mod tests {
             input.as_ref(),
             temp_dir.path().to_string_lossy().as_ref(),
         )
-            .await
-            .expect("epg path");
+        .await
+        .expect("epg path");
         if let Some(parent) = raw_epg_path.parent() {
             tokio::fs::create_dir_all(parent).await.expect("epg dir");
         }
@@ -1158,8 +1122,8 @@ mod tests {
 </tv>"#
             ),
         )
-            .await
-            .expect("write epg");
+        .await
+        .expect("write epg");
 
         let app_state = test_app_state(Arc::new(app_config));
         let router = super::v1_api_playlist_register_protected(Router::new()).with_state(app_state);
@@ -1193,10 +1157,7 @@ mod tests {
             provider_configs: Some(vec![Arc::new(provider)]),
             ..Default::default()
         });
-        let source = ConfigSource {
-            inputs: vec![Arc::clone(&input.name)],
-            targets: vec![],
-        };
+        let source = ConfigSource { inputs: vec![Arc::clone(&input.name)], targets: vec![] };
         let app_state = test_app_state(Arc::new(test_app_config(input, source)));
         let router = super::v1_api_playlist_register_protected(Router::new()).with_state(app_state);
         let request = Request::builder()
@@ -1228,16 +1189,8 @@ mod tests {
             name: "input".intern(),
             epg: Some(crate::model::EpgConfig::from(&EpgConfigDto {
                 sources: Some(vec![
-                    EpgSourceDto {
-                        url: secondary_url.to_string(),
-                        priority: 10,
-                        logo_override: false,
-                    },
-                    EpgSourceDto {
-                        url: primary_url.to_string(),
-                        priority: 0,
-                        logo_override: false,
-                    },
+                    EpgSourceDto { url: secondary_url.to_string(), priority: 10, logo_override: false },
+                    EpgSourceDto { url: primary_url.to_string(), priority: 0, logo_override: false },
                     EpgSourceDto {
                         url: "provider://demo/xmltv-same-priority.php?username=user&password=pass".to_string(),
                         priority: 0,
@@ -1245,16 +1198,8 @@ mod tests {
                     },
                 ]),
                 t_sources: vec![
-                    EpgSourceDto {
-                        url: secondary_url.to_string(),
-                        priority: 10,
-                        logo_override: false,
-                    },
-                    EpgSourceDto {
-                        url: primary_url.to_string(),
-                        priority: 0,
-                        logo_override: false,
-                    },
+                    EpgSourceDto { url: secondary_url.to_string(), priority: 10, logo_override: false },
+                    EpgSourceDto { url: primary_url.to_string(), priority: 0, logo_override: false },
                     EpgSourceDto {
                         url: "provider://demo/xmltv-same-priority.php?username=user&password=pass".to_string(),
                         priority: 0,
@@ -1266,10 +1211,7 @@ mod tests {
             provider_configs: Some(vec![Arc::new(provider)]),
             ..Default::default()
         });
-        let source = ConfigSource {
-            inputs: vec![Arc::clone(&input.name)],
-            targets: vec![],
-        };
+        let source = ConfigSource { inputs: vec![Arc::clone(&input.name)], targets: vec![] };
         let app_config = test_app_config(input.clone(), source);
         app_config.config.store(Arc::new(Config {
             storage_dir: temp_dir.path().to_string_lossy().to_string(),
@@ -1281,22 +1223,22 @@ mod tests {
             input.as_ref(),
             temp_dir.path().to_string_lossy().as_ref(),
         )
-            .await
-            .expect("primary epg path");
+        .await
+        .expect("primary epg path");
         let secondary_path = get_input_raw_epg_file_path(
             "http://provider.example/xmltv-secondary.php?username=user&password=pass",
             input.as_ref(),
             temp_dir.path().to_string_lossy().as_ref(),
         )
-            .await
-            .expect("secondary epg path");
+        .await
+        .expect("secondary epg path");
         let same_priority_path = get_input_raw_epg_file_path(
             "http://provider.example/xmltv-same-priority.php?username=user&password=pass",
             input.as_ref(),
             temp_dir.path().to_string_lossy().as_ref(),
         )
-            .await
-            .expect("same priority epg path");
+        .await
+        .expect("same priority epg path");
 
         for path in [&primary_path, &secondary_path, &same_priority_path] {
             if let Some(parent) = path.parent() {
@@ -1324,8 +1266,8 @@ mod tests {
 </tv>"#
             ),
         )
-            .await
-            .expect("write secondary epg");
+        .await
+        .expect("write secondary epg");
         tokio::fs::write(
             &primary_path,
             format!(
@@ -1341,8 +1283,8 @@ mod tests {
 </tv>"#
             ),
         )
-            .await
-            .expect("write primary epg");
+        .await
+        .expect("write primary epg");
         tokio::fs::write(
             &same_priority_path,
             format!(
@@ -1361,8 +1303,8 @@ mod tests {
 </tv>"#
             ),
         )
-            .await
-            .expect("write same priority epg");
+        .await
+        .expect("write same priority epg");
 
         let app_state = test_app_state(Arc::new(app_config));
         let router = super::v1_api_playlist_register_protected(Router::new()).with_state(app_state);

--- a/backend/src/processing/parser/xmltv.rs
+++ b/backend/src/processing/parser/xmltv.rs
@@ -1,4 +1,7 @@
-use crate::model::{Epg, TVGuide, XmlTag, XmlTagIcon, EPG_ATTRIB_CHANNEL, EPG_ATTRIB_ID, EPG_TAG_CHANNEL, EPG_TAG_DISPLAY_NAME, EPG_TAG_ICON, EPG_TAG_PROGRAMME, EPG_TAG_TV};
+use crate::model::{
+    EPG_ATTRIB_CHANNEL, EPG_ATTRIB_ID, EPG_TAG_CHANNEL, EPG_TAG_DISPLAY_NAME, EPG_TAG_ICON, EPG_TAG_PROGRAMME,
+    EPG_TAG_TV, Epg, TVGuide, XmlTag, XmlTagIcon,
+};
 use crate::model::{EpgSmartMatchConfig, PersistedEpgSource};
 use crate::processing::processor::EpgIdCache;
 use crate::utils::compressed_file_reader_async::CompressedFileReaderAsync;
@@ -8,7 +11,7 @@ use quick_xml::events::{BytesStart, BytesText, Event};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use shared::concat_string;
 use shared::model::{EpgChannel, EpgNamePrefix, EpgProgramme};
-use shared::utils::{deunicode_string, Internable, CONSTANTS};
+use shared::utils::{CONSTANTS, Internable, deunicode_string};
 use std::borrow::Cow;
 use std::cmp::min;
 use std::collections::{HashMap, HashSet};
@@ -49,7 +52,6 @@ fn split_by_first_match<'a>(input: &'a str, delimiters: &[char]) -> (Option<&'a 
     (None, input)
 }
 
-
 fn name_prefix<'a>(name: &'a str, smart_config: &EpgSmartMatchConfig) -> (&'a str, Option<&'a str>) {
     if smart_config.name_prefix != EpgNamePrefix::Ignore {
         let (prefix, suffix) = split_by_first_match(name, &smart_config.name_prefix_separator);
@@ -75,33 +77,23 @@ pub fn normalize_channel_name(name: &str, normalize_config: &EpgSmartMatchConfig
     // Remove all non-alphanumeric characters (except dashes and underscores).
     let cleaned_name = normalize_config.normalize_regex.replace_all(channel_name, "");
     // Remove terms like resolution
-    let cleaned_name = normalize_config.strip.iter().fold(cleaned_name.to_string(), |acc, term| {
-        acc.replace(term, "")
-    });
+    let cleaned_name = normalize_config.strip.iter().fold(cleaned_name.to_string(), |acc, term| acc.replace(term, ""));
     match suffix {
         None => cleaned_name,
-        Some(sfx) => {
-            match &normalize_config.name_prefix {
-                EpgNamePrefix::Ignore => cleaned_name,
-                EpgNamePrefix::Suffix(sep) => combine(sep, &cleaned_name, sfx),
-                EpgNamePrefix::Prefix(sep) => combine(sep, sfx, &cleaned_name),
-            }
-        }
+        Some(sfx) => match &normalize_config.name_prefix {
+            EpgNamePrefix::Ignore => cleaned_name,
+            EpgNamePrefix::Suffix(sep) => combine(sep, &cleaned_name, sfx),
+            EpgNamePrefix::Prefix(sep) => combine(sep, sfx, &cleaned_name),
+        },
     }
 }
-
 
 impl TVGuide {
     pub fn merge(epgs: Vec<Epg>) -> Option<Epg> {
         if let Some(first_epg) = epgs.first() {
             let first_epg_attributes = first_epg.attributes.clone();
             let merged_children: Vec<Arc<EpgChannel>> = epgs.into_iter().flat_map(|epg| epg.children).collect();
-            Some(Epg {
-                logo_override: false,
-                priority: 0,
-                attributes: first_epg_attributes,
-                children: merged_children,
-            })
+            Some(Epg { logo_override: false, priority: 0, attributes: first_epg_attributes, children: merged_children })
         } else {
             None
         }
@@ -109,9 +101,7 @@ impl TVGuide {
 
     fn prepare_tag(id_cache: &mut EpgIdCache, tag: &mut XmlTag, smart_match: bool) {
         {
-            let maybe_epg_id = {
-                tag.get_attribute_value(&EPG_ATTRIB_ID.intern()).cloned()
-            };
+            let maybe_epg_id = { tag.get_attribute_value(&EPG_ATTRIB_ID.intern()).cloned() };
             if let Some(epg_id) = maybe_epg_id {
                 tag.normalized_epg_ids
                     .get_or_insert_with(Vec::new)
@@ -124,11 +114,11 @@ impl TVGuide {
             for child in children {
                 match child.name.as_ref() {
                     EPG_TAG_DISPLAY_NAME if smart_match => {
-                            if let Some(name) = &child.value {
-                                tag.normalized_epg_ids
-                                    .get_or_insert_with(Vec::new)
-                                    .push(normalize_channel_name(name, &id_cache.smart_match_config).intern());
-                            }
+                        if let Some(name) = &child.value {
+                            tag.normalized_epg_ids
+                                .get_or_insert_with(Vec::new)
+                                .push(normalize_channel_name(name, &id_cache.smart_match_config).intern());
+                        }
                     }
                     EPG_TAG_ICON => {
                         if let Some(src) = child.get_attribute_value(&src) {
@@ -146,10 +136,8 @@ impl TVGuide {
     }
 
     fn try_fuzzy_matching(id_cache: &mut EpgIdCache, epg_id: &Arc<str>, tag: &XmlTag, fuzzy_matching: bool) -> bool {
-        let mut matched = tag
-            .normalized_epg_ids
-            .as_ref()
-            .is_some_and(|ids| id_cache.match_with_normalized(epg_id, ids));
+        let mut matched =
+            tag.normalized_epg_ids.as_ref().is_some_and(|ids| id_cache.match_with_normalized(epg_id, ids));
         if !matched && fuzzy_matching {
             let (fuzzy_matched, matched_normalized_name) = Self::find_best_fuzzy_match(id_cache, tag);
             if fuzzy_matched {
@@ -163,6 +151,96 @@ impl TVGuide {
             }
         }
         matched
+    }
+
+    fn channel_display_name(tag: &XmlTag) -> Option<Arc<str>> {
+        tag.children.as_ref().and_then(|children| {
+            children
+                .iter()
+                .find(|c| c.name.as_ref() == EPG_TAG_DISPLAY_NAME)
+                .and_then(|c| c.value.clone())
+        })
+    }
+
+    fn add_channel_tag(
+        id_cache: &mut EpgIdCache,
+        children: &mut HashMap<Arc<str>, EpgChannel>,
+        tag: &mut XmlTag,
+        smart_match: bool,
+        fuzzy_matching: bool,
+    ) {
+        let tag_epg_id =
+            tag.get_attribute_value(&EPG_ATTRIB_ID.intern()).map_or_else(|| "".intern(), Internable::intern);
+        if tag_epg_id.is_empty() || id_cache.processed.contains(&tag_epg_id) {
+            return;
+        }
+
+        Self::prepare_tag(id_cache, tag, smart_match);
+        let add_channel = if smart_match {
+            Self::try_fuzzy_matching(id_cache, &tag_epg_id, tag, fuzzy_matching)
+        } else {
+            id_cache.channel_epg_id.contains(&tag_epg_id)
+        };
+
+        if add_channel && !children.contains_key(&tag_epg_id) {
+            children.insert(
+                Arc::clone(&tag_epg_id),
+                EpgChannel {
+                    id: Arc::clone(&tag_epg_id),
+                    title: Self::channel_display_name(tag),
+                    icon: if let XmlTagIcon::Src(src) = &tag.icon { Some(Arc::clone(src)) } else { None },
+                    programmes: vec![],
+                },
+            );
+            id_cache.processed.insert(tag_epg_id);
+        }
+    }
+
+    fn add_programme_tag(
+        children: &mut HashMap<Arc<str>, EpgChannel>,
+        tag: &XmlTag,
+        epg_id: &Arc<str>,
+        start_attrib: &Arc<str>,
+        stop_attrib: &Arc<str>,
+        tag_title: &Arc<str>,
+        tag_desc: &Arc<str>,
+    ) {
+        let Some(channel) = children.get_mut(epg_id) else {
+            error!("Channel {epg_id} not found in EPG, dangling programme");
+            return;
+        };
+
+        let Some((Some(start), Some(stop))) =
+            tag.attributes.as_ref().map(|a| (a.get(start_attrib), a.get(stop_attrib)))
+        else {
+            error!("Missing start or stop attribute in programme tag, skipping");
+            return;
+        };
+
+        let (Some(start_time), Some(stop_time)) = (parse_xmltv_time(start), parse_xmltv_time(stop)) else {
+            error!("Failed to parse epg programme time {start} - {stop}");
+            return;
+        };
+
+        let mut title = None;
+        let mut desc = None;
+        if let Some(children) = tag.children.as_ref() {
+            for child in children {
+                if child.name == *tag_title {
+                    title.clone_from(&child.value);
+                } else if child.name == *tag_desc {
+                    desc.clone_from(&child.value);
+                }
+            }
+        }
+
+        channel.programmes.push(EpgProgramme::new_all(
+            start_time,
+            stop_time,
+            Arc::clone(epg_id),
+            title,
+            desc,
+        ));
     }
 
     /// Finds the best fuzzy match for a channel's normalized EPG ID using phonetic encoding and Jaro-Winkler similarity.
@@ -192,10 +270,8 @@ impl TVGuide {
         };
 
         // 1) Precalculation: (tag_normalized, tag_code)
-        let pre: Vec<(Arc<str>, Arc<str>)> = normalized_epg_ids
-            .iter()
-            .map(|tn| (tn.clone(), id_cache.phonetic(tn)))
-            .collect();
+        let pre: Vec<(Arc<str>, Arc<str>)> =
+            normalized_epg_ids.iter().map(|tn| (tn.clone(), id_cache.phonetic(tn))).collect();
 
         // 2) Early exit if match >= best_match_threshold
         for (tag_normalized, tag_code) in &pre {
@@ -254,7 +330,6 @@ impl TVGuide {
     /// }
     /// ```
     async fn process_epg_file(id_cache: &mut EpgIdCache, epg_source: &PersistedEpgSource) -> Option<Epg> {
-        let epg_attrib_id = EPG_ATTRIB_ID.intern();
         let epg_attrib_channel = EPG_ATTRIB_CHANNEL.intern();
         let start_attrib = "start".intern();
         let stop_attrib = "stop".intern();
@@ -269,62 +344,19 @@ impl TVGuide {
                 let fuzzy_matching = smart_match && id_cache.smart_match_config.fuzzy_matching;
                 let mut filter_tags = |mut tag: XmlTag| {
                     match tag.name.as_ref() {
-                        EPG_TAG_CHANNEL => {
-                            let tag_epg_id = tag.get_attribute_value(&epg_attrib_id).map_or_else(|| "".intern(), Internable::intern);
-                            if !tag_epg_id.is_empty() && !id_cache.processed.contains(&tag_epg_id) {
-                                Self::prepare_tag(id_cache, &mut tag, smart_match);
-                                let mut add_channel = false;
-                                if smart_match {
-                                    if Self::try_fuzzy_matching(id_cache, &tag_epg_id, &tag, fuzzy_matching) {
-                                        add_channel = true;
-                                    }
-                                } else if id_cache.channel_epg_id.contains(&tag_epg_id) {
-                                    add_channel = true;
-                                }
-
-                                if add_channel && !children.contains_key(&tag_epg_id) {
-                                    let display_name = tag.children.as_ref().and_then(|children| {
-                                        children.iter()
-                                            .find(|c| c.name.as_ref() == EPG_TAG_DISPLAY_NAME)
-                                            .and_then(|c| c.value.clone())
-                                    });
-                                    children.insert(Arc::clone(&tag_epg_id), EpgChannel {
-                                        id: Arc::clone(&tag_epg_id),
-                                        title: display_name,
-                                        icon: if let XmlTagIcon::Src(src) = &tag.icon { Some(Arc::clone(src)) } else { None },
-                                        programmes: vec![],
-                                    });
-                                    id_cache.processed.insert(tag_epg_id);
-                                }
-                            }
-                        }
+                        EPG_TAG_CHANNEL => Self::add_channel_tag(id_cache, &mut children, &mut tag, smart_match, fuzzy_matching),
                         EPG_TAG_PROGRAMME => {
                             if let Some(epg_id) = tag.get_attribute_value(&epg_attrib_channel) {
-                                if id_cache.processed.contains(epg_id) /*&& id_cache.channel_epg_id.contains(epg_id) */{
-                                    if let Some(channel) = children.get_mut(epg_id) {
-                                        if let Some((Some(start), Some(stop))) = tag.attributes.as_ref().map(|a| (a.get(&start_attrib), a.get(&stop_attrib))) {
-                                            if let (Some(start_time), Some(stop_time)) = (parse_xmltv_time(start), parse_xmltv_time(stop)) {
-                                                let mut title = None;
-                                                let mut desc = None;
-                                                if let Some(children) = tag.children.as_ref() {
-                                                    for child in children {
-                                                        if child.name == tag_title {
-                                                            title.clone_from(&child.value);
-                                                        } else if child.name == tag_desc {
-                                                            desc.clone_from(&child.value);
-                                                        }
-                                                    }
-                                                    channel.programmes.push(EpgProgramme::new_all(start_time, stop_time, Arc::clone(epg_id), title, desc));
-                                                }
-                                            } else {
-                                                error!("Failed to parse epg programme time {start} - {stop}");
-                                            }
-                                        } else {
-                                            error!("Missing start or stop attribute in programme tag, skipping");
-                                        }
-                                    } else {
-                                        error!("Channel {epg_id} not found in EPG, dangling programme");
-                                    }
+                                if id_cache.processed.contains(epg_id) {
+                                    Self::add_programme_tag(
+                                        &mut children,
+                                        &tag,
+                                        epg_id,
+                                        &start_attrib,
+                                        &stop_attrib,
+                                        &tag_title,
+                                        &tag_desc,
+                                    );
                                 }
                             }
                         }
@@ -361,6 +393,7 @@ impl TVGuide {
         }
         let mut epg_sources: Vec<Epg> = vec![];
         for epg_source in self.get_epg_sources() {
+            id_cache.processed.clear();
             if let Some(epg) = Self::process_epg_file(id_cache, epg_source).await {
                 epg_sources.push(epg);
             }
@@ -494,12 +527,14 @@ fn get_tag_type(name: &str) -> XmlTagType {
         EPG_TAG_TV => XmlTagType::Tv,
         EPG_TAG_CHANNEL => XmlTagType::Channel,
         EPG_TAG_PROGRAMME => XmlTagType::Programme,
-        _ => XmlTagType::Ignored
+        _ => XmlTagType::Ignored,
     }
 }
 
 fn collect_tag_attributes(e: &BytesStart, tag_type: XmlTagType) -> HashMap<Arc<str>, Arc<str>> {
-    let attributes = e.attributes().filter_map(Result::ok)
+    let attributes = e
+        .attributes()
+        .filter_map(Result::ok)
         .filter_map(|a| {
             let key_binding = a.key;
             let key_raw = String::from_utf8_lossy(key_binding.as_ref());
@@ -507,7 +542,9 @@ fn collect_tag_attributes(e: &BytesStart, tag_type: XmlTagType) -> HashMap<Arc<s
             if let Ok(value) = a.unescape_value().as_ref() {
                 if value.is_empty() {
                     None
-                } else if (tag_type.is_channel() && key.as_ref() == EPG_ATTRIB_ID) || (tag_type.is_program() && key.as_ref() == EPG_ATTRIB_CHANNEL) {
+                } else if (tag_type.is_channel() && key.as_ref() == EPG_ATTRIB_ID)
+                    || (tag_type.is_program() && key.as_ref() == EPG_ATTRIB_CHANNEL)
+                {
                     Some((key, value.to_lowercase().intern()))
                 } else {
                     Some((key, value.intern()))
@@ -515,7 +552,8 @@ fn collect_tag_attributes(e: &BytesStart, tag_type: XmlTagType) -> HashMap<Arc<s
             } else {
                 None
             }
-        }).collect::<HashMap<Arc<str>, Arc<str>>>();
+        })
+        .collect::<HashMap<Arc<str>, Arc<str>>>();
     attributes
 }
 
@@ -527,10 +565,7 @@ struct ProgrammeKey {
 
 impl From<&EpgProgramme> for ProgrammeKey {
     fn from(p: &EpgProgramme) -> Self {
-        Self {
-            start: p.start,
-            stop: p.stop,
-        }
+        Self { start: p.start, stop: p.stop }
     }
 }
 
@@ -540,14 +575,24 @@ struct ChannelAcc {
     programmes: HashSet<ProgrammeKey>,
 }
 
+fn merge_missing_programmes<I>(channel: &mut EpgChannel, programmes: &mut HashSet<ProgrammeKey>, incoming: I)
+where
+    I: IntoIterator<Item = EpgProgramme>,
+{
+    for programme in incoming {
+        let key = ProgrammeKey::from(&programme);
+        if programmes.insert(key) {
+            channel.programmes.push(programme);
+        }
+    }
+}
+
 pub fn flatten_tvguide(mut tv_guides: Vec<Epg>) -> Option<Epg> {
     if tv_guides.is_empty() {
         return None;
     }
 
-    let epg_attributes = tv_guides
-        .first()
-        .and_then(|t| t.attributes.clone());
+    let epg_attributes = tv_guides.first().and_then(|t| t.attributes.clone());
 
     let mut channels: HashMap<Arc<str>, ChannelAcc> = HashMap::new();
 
@@ -562,22 +607,18 @@ pub fn flatten_tvguide(mut tv_guides: Vec<Epg>) -> Option<Epg> {
                     let acc = entry.get_mut();
 
                     if guide.priority < acc.priority {
-                        // high priority
+                        // Higher-priority sources own channel metadata, but lower-priority
+                        // programmes still fill gaps when the preferred source is incomplete.
+                        let previous_programmes = std::mem::replace(&mut acc.channel, channel).programmes;
                         acc.priority = guide.priority;
-                        acc.channel = channel;
 
                         acc.programmes.clear();
                         for p in &acc.channel.programmes {
                             acc.programmes.insert(ProgrammeKey::from(p));
                         }
-                    } else if guide.priority == acc.priority {
-                        // same priority -> merge
-                        for p in channel.programmes.drain(..) {
-                            let key = ProgrammeKey::from(&p);
-                            if acc.programmes.insert(key) {
-                                acc.channel.programmes.push(p);
-                            }
-                        }
+                        merge_missing_programmes(&mut acc.channel, &mut acc.programmes, previous_programmes);
+                    } else {
+                        merge_missing_programmes(&mut acc.channel, &mut acc.programmes, channel.programmes.drain(..));
                     }
                 }
 
@@ -587,35 +628,31 @@ pub fn flatten_tvguide(mut tv_guides: Vec<Epg>) -> Option<Epg> {
                         set.insert(ProgrammeKey::from(p));
                     }
 
-                    entry.insert(ChannelAcc {
-                        priority: guide.priority,
-                        channel,
-                        programmes: set,
-                    });
+                    entry.insert(ChannelAcc { priority: guide.priority, channel, programmes: set });
                 }
             }
         }
     }
 
-    let children = channels
-        .into_values()
-        .map(|acc| Arc::new(acc.channel))
-        .collect();
+    for acc in channels.values_mut() {
+        acc.channel.programmes.sort_by_key(|programme| programme.start);
+    }
 
-    Some(Epg {
-        logo_override: false,
-        priority: 0,
-        attributes: epg_attributes,
-        children,
-    })
+    let children = channels.into_values().map(|acc| Arc::new(acc.channel)).collect();
+
+    Some(Epg { logo_override: false, priority: 0, attributes: epg_attributes, children })
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::model::{EpgSmartMatchConfig, PersistedEpgSource, TVGuide};
+    use crate::model::{Epg, EpgSmartMatchConfig, PersistedEpgSource, TVGuide};
     use crate::processing::parser::xmltv::normalize_channel_name;
+    use shared::model::{EpgChannel, EpgProgramme};
+    use std::fs;
     use std::collections::HashSet;
     use std::path::PathBuf;
+    use std::sync::Arc;
+    use tempfile::tempdir;
 
     #[test]
     /// Tests normalization of a channel name using the default smart match configuration.
@@ -632,6 +669,114 @@ mod tests {
         assert_eq!(normalized, "lovenature".to_string());
     }
 
+    #[test]
+    fn flatten_tvguide_prefers_higher_priority_metadata_and_merges_all_programmes() {
+        let low_priority = Epg {
+            logo_override: false,
+            priority: 10,
+            attributes: None,
+            children: vec![Arc::new(EpgChannel {
+                id: "demo.channel".intern(),
+                title: Some("Low".intern()),
+                icon: Some("http://low/icon.png".intern()),
+                programmes: vec![EpgProgramme::new_all(
+                    10,
+                    20,
+                    "demo.channel".intern(),
+                    Some("Low Show".intern()),
+                    None,
+                )],
+            })],
+        };
+        let high_priority = Epg {
+            logo_override: false,
+            priority: 0,
+            attributes: None,
+            children: vec![Arc::new(EpgChannel {
+                id: "demo.channel".intern(),
+                title: Some("High".intern()),
+                icon: Some("http://high/icon.png".intern()),
+                programmes: vec![EpgProgramme::new_all(
+                    30,
+                    40,
+                    "demo.channel".intern(),
+                    Some("High Show".intern()),
+                    None,
+                )],
+            })],
+        };
+
+        let epg = super::flatten_tvguide(vec![low_priority, high_priority]).expect("merged epg");
+        assert_eq!(epg.children.len(), 1);
+        assert_eq!(epg.children[0].title.as_deref(), Some("High"));
+        assert_eq!(epg.children[0].icon.as_deref(), Some("http://high/icon.png"));
+        assert_eq!(
+            epg.children[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
+            vec![(10, 20), (30, 40)],
+        );
+    }
+
+    #[test]
+    fn filter_keeps_same_channel_id_across_sources_for_flattening() {
+        let run_test = async move {
+            let dir = tempdir().unwrap();
+            let source_one = dir.path().join("one.xml");
+            let source_two = dir.path().join("two.xml");
+
+            fs::write(
+                &source_one,
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="demo.channel">
+    <display-name>Demo One</display-name>
+  </channel>
+  <programme start="20260425000000 +0000" stop="20260425010000 +0000" channel="demo.channel">
+    <title>Low Source</title>
+  </programme>
+</tv>
+"#,
+            )
+            .unwrap();
+            fs::write(
+                &source_two,
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="demo.channel">
+    <display-name>Demo Two</display-name>
+  </channel>
+  <programme start="20260425010000 +0000" stop="20260425020000 +0000" channel="demo.channel">
+    <title>High Source</title>
+  </programme>
+</tv>
+"#,
+            )
+            .unwrap();
+
+            let tv_guide = TVGuide::new(vec![
+                PersistedEpgSource { file_path: source_one.clone(), priority: 10, logo_override: false },
+                PersistedEpgSource { file_path: source_two.clone(), priority: 0, logo_override: false },
+            ]);
+
+            let mut id_cache = EpgIdCache::new(None);
+            id_cache.channel_epg_id.insert("demo.channel".intern());
+
+            let epgs = tv_guide.filter(&mut id_cache).await.expect("filtered epgs");
+            assert_eq!(epgs.len(), 2);
+
+            let flattened = super::flatten_tvguide(epgs).expect("flattened epg");
+
+            assert_eq!(flattened.children.len(), 1);
+            assert_eq!(flattened.children[0].programmes.len(), 2);
+            let titles: Vec<_> = flattened.children[0]
+                .programmes
+                .iter()
+                .filter_map(|programme| programme.title.as_deref())
+                .collect();
+            assert_eq!(titles, vec!["Low Source", "High Source"]);
+        };
+
+        tokio::runtime::Runtime::new().unwrap().block_on(run_test);
+    }
 
     #[ignore = "requires a local XMLTV fixture under /tmp"]
     #[test]
@@ -658,9 +803,7 @@ mod tests {
                 }
             }
         };
-        tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(run_test());
+        tokio::runtime::Runtime::new().unwrap().block_on(run_test());
     }
 
     #[test]
@@ -673,7 +816,11 @@ mod tests {
     /// // This will assert that various channel names are normalized as expected.
     /// ```
     fn normalize() {
-        let mut epg_smart_cfg_dto = EpgSmartMatchConfigDto { enabled: true, name_prefix: EpgNamePrefix::Suffix(".".to_string()), ..Default::default() };
+        let mut epg_smart_cfg_dto = EpgSmartMatchConfigDto {
+            enabled: true,
+            name_prefix: EpgNamePrefix::Suffix(".".to_string()),
+            ..Default::default()
+        };
         let _ = epg_smart_cfg_dto.prepare();
         let epg_smart_cfg = EpgSmartMatchConfig::from(epg_smart_cfg_dto);
         println!("{epg_smart_cfg:?}");
@@ -703,7 +850,11 @@ mod tests {
     /// ```
     fn test_metaphone() {
         let metaphone = Metaphone::default();
-        let mut epg_smart_cfg_dto = EpgSmartMatchConfigDto { enabled: true, name_prefix: EpgNamePrefix::Suffix(".".to_string()), ..Default::default() };
+        let mut epg_smart_cfg_dto = EpgSmartMatchConfigDto {
+            enabled: true,
+            name_prefix: EpgNamePrefix::Suffix(".".to_string()),
+            ..Default::default()
+        };
         let _ = epg_smart_cfg_dto.prepare();
         let epg_smart_cfg = EpgSmartMatchConfig::from(epg_smart_cfg_dto);
         println!("{epg_smart_cfg:?}");

--- a/epg_merge_patch.md
+++ b/epg_merge_patch.md
@@ -1,0 +1,67 @@
+# Tuliprox local patch: EPG programme fallback merge
+
+Date: 2026-04-25
+
+## Problem
+
+Tuliprox can load multiple XMLTV sources for one input. The upstream merge logic
+selected one complete channel by `epg.sources[].priority`.
+
+When a higher-priority XMLTV source contains a channel ID but has an incomplete
+programme range, lower-priority sources for the same channel ID are ignored. This
+caused selected Consumer XMLTV IDs to stop early even though another configured
+source still had current/future programmes.
+
+Observed affected IDs:
+
+- `zdf.de`
+- `3sat.de`
+- `arte.de`
+- `rtl.de`
+- `vox.de`
+- `zdfinfo.de`
+
+## Local change
+
+Changed EPG merging so source priority still decides channel metadata
+(`title`, `icon`), but programmes from all sources are merged as fallback data
+and deduplicated by `(start, stop)`.
+
+Changed files:
+
+- `/root/tuliprox/backend/src/processing/parser/xmltv.rs`
+  - `flatten_tvguide()` now keeps higher-priority metadata and fills missing
+    programmes from lower-priority sources.
+- `/root/tuliprox/backend/src/api/endpoints/v1_api_playlist.rs`
+  - Web UI EPG merge now follows the same programme fallback behavior.
+
+## After an upgrade
+
+Re-check whether upstream still has the old behavior:
+
+```bash
+cd /root/tuliprox
+rg -n "fn flatten_tvguide|merge_epg_channels|guide.priority < acc.priority|priority < acc.priority" backend/src
+```
+
+If upstream still replaces the complete channel when a higher-priority source
+wins, re-apply this patch.
+
+Expected behavior after patch:
+
+- Higher-priority source wins for channel metadata.
+- All sources can contribute programme entries for the same `channel.id`.
+- Duplicate programme entries are ignored when `start` and `stop` are identical.
+
+## Verification commands
+
+Run the targeted tests:
+
+```bash
+cd /root/tuliprox
+cargo test -p tuliprox flatten_tvguide_prefers_higher_priority_metadata_and_merges_all_programmes
+cargo test -p tuliprox merge_epg_channels_prefers_higher_priority_metadata_and_merges_all_programmes
+```
+
+Then rebuild and replace the installed binary under `/opt/tuliprox` before
+refreshing the `German-Only` target.


### PR DESCRIPTION
This PR fixes a bug in the EPG merge logic for Tuliprox.

Root cause:
- When multiple XMLTV sources were configured for the same channel, the higher-priority source replaced the entire channel entry.
- That caused valid programme data from lower-priority sources to be dropped, even when the higher-priority source was incomplete.

What changed:
- Preserve higher-priority channel metadata.
- Merge programme entries from all configured sources as fallback data.
- Deduplicate programmes by `(start, stop)`.
- Apply the same behavior to the Web UI/API merge path.
- Add a local upgrade note with the regression check and verification commands.

Validation:
- `cargo test -p tuliprox flatten_tvguide_prefers_higher_priority_metadata_and_merges_all_programmes`
- `cargo test -p tuliprox merge_epg_channels_prefers_higher_priority_metadata_and_merges_all_programmes`
- Rebuilt and redeployed the service locally, then verified that the affected XMLTV IDs now extend into the current and next days.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * EPG merging now preserves channel metadata from higher-priority sources while retaining and deduplicating programmes from all sources, with deterministic ordering.

* **Documentation**
  * Added a document describing the EPG merge behavior, failure mode, and verification steps.

* **Chores**
  * Updated ignore rules to avoid committing local analysis outputs while tracking the new EPG merge doc.

* **Tests**
  * Added unit and integration tests validating the revised EPG merge semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->