### PR TITLE
Fix EPG merge prioritization across XMLTV sources

### DIFF
--- a/backend/src/api/endpoints/v1_api_playlist.rs
+++ b/backend/src/api/endpoints/v1_api_playlist.rs
@@ -1,27 +1,38 @@
 use crate::api::api_utils::resource_response;
-use crate::{api::{
-    api_utils::{create_api_proxy_user, json_or_bin_response},
-    endpoints::{
-        api_playlist_utils::{get_playlist_for_custom_provider, get_playlist_for_input, get_playlist_for_target},
-        extract_accept_header::ExtractAcceptHeader,
-        xmltv_api::{rewrite_epg_channel_resource_url, serve_epg_web_ui, stream_epg_api},
-        xtream_api::xtream_get_stream_info_response,
+use crate::{
+    api::{
+        api_utils::{create_api_proxy_user, json_or_bin_response},
+        endpoints::{
+            api_playlist_utils::{get_playlist_for_custom_provider, get_playlist_for_input, get_playlist_for_target},
+            extract_accept_header::ExtractAcceptHeader,
+            xmltv_api::{rewrite_epg_channel_resource_url, serve_epg_web_ui, stream_epg_api},
+            xtream_api::xtream_get_stream_info_response,
+        },
+        model::AppState,
     },
-    model::AppState,
-}, auth::{create_access_token, permission_layer}, model::{parse_xmltv_for_web_ui_from_file, parse_xmltv_for_web_ui_from_url, AppConfig, ConfigInput, ConfigInputFlags, ConfigInputOptions}, repository::xtream_get_item_for_stream_id, utils::{epg::get_input_raw_epg_file_path, file_exists_async}};
-use axum::{response::IntoResponse, Router};
+    auth::{create_access_token, permission_layer},
+    model::{
+        parse_xmltv_for_web_ui_from_file, parse_xmltv_for_web_ui_from_url, AppConfig, ConfigInput, ConfigInputFlags,
+        ConfigInputOptions,
+    },
+    repository::xtream_get_item_for_stream_id,
+    utils::{epg::get_input_raw_epg_file_path, file_exists_async, merge_prioritized_channels},
+};
+use axum::{
+    response::{IntoResponse, Response},
+    Router,
+};
 use log::{debug, error};
 use serde_json::json;
 use shared::utils::deobfuscate_text;
 use shared::{
     model::{
-        permission::Permission, EpgChannel, EpgProgramme,
-        InputType, PlaylistEpgRequest, PlaylistRequest, PlaylistUrlResolveRequest, ProxyType, TargetType, UiPlaylistItem,
-        XtreamCluster,
+        permission::Permission, EpgChannel, InputType, PlaylistEpgRequest, PlaylistRequest, PlaylistUrlResolveRequest,
+        ProxyType, TargetType, UiPlaylistItem, XtreamCluster,
     },
     utils::{concat_path_leading_slash, sanitize_sensitive_info, Internable},
 };
-use std::{collections::{HashMap, HashSet}, sync::Arc};
+use std::sync::Arc;
 use url::Url;
 
 fn create_config_input_for_m3u(url: &str) -> ConfigInput {
@@ -90,9 +101,7 @@ fn resolve_provider_url_for_request(app_config: &AppConfig, playlist_request: &P
             .get_target_by_id(*target_id)
             .and_then(|target| app_config.get_inputs_for_target(&target.name))
             .and_then(|inputs| {
-                let mut matches = inputs
-                    .into_iter()
-                    .filter(|input| input.get_resolve_provider(url).is_some());
+                let mut matches = inputs.into_iter().filter(|input| input.get_resolve_provider(url).is_some());
                 let first = matches.next()?;
                 if matches.next().is_some() {
                     return None;
@@ -111,84 +120,23 @@ fn build_playlist_webplayer_url(
     virtual_id: u32,
     cluster: XtreamCluster,
 ) -> String {
-    format!(
-        "{base_url}/token/{access_token}/{}/{}/{}",
-        target_id,
-        cluster.as_stream_type(),
-        virtual_id
-    )
+    format!("{base_url}/token/{access_token}/{}/{}/{}", target_id, cluster.as_stream_type(), virtual_id)
 }
 
-#[derive(Hash, Eq, PartialEq)]
-struct WebUiProgrammeKey {
-    start: i64,
-    stop: i64,
+fn merge_epg_channels(channels_by_source: Vec<(i16, Vec<EpgChannel>)>) -> Vec<EpgChannel> {
+    merge_prioritized_channels(channels_by_source)
 }
 
-impl From<&EpgProgramme> for WebUiProgrammeKey {
-    fn from(programme: &EpgProgramme) -> Self {
-        Self {
-            start: programme.start,
-            stop: programme.stop,
-        }
-    }
-}
-
-struct WebUiChannelAcc {
-    priority: i16,
-    channel: EpgChannel,
-    programmes: HashSet<WebUiProgrammeKey>,
-}
-
-fn merge_epg_channels(mut channels_by_source: Vec<(i16, Vec<EpgChannel>)>) -> Vec<EpgChannel> {
-    let mut merged: HashMap<Arc<str>, WebUiChannelAcc> = HashMap::new();
-    channels_by_source.sort_by_key(|(priority, _)| *priority);
-
-    for (priority, channels) in channels_by_source.drain(..) {
-        for channel in channels {
-            match merged.entry(channel.id.clone()) {
-                std::collections::hash_map::Entry::Occupied(mut entry) => {
-                    let acc = entry.get_mut();
-                    if priority < acc.priority {
-                        let programmes = channel
-                            .programmes
-                            .iter()
-                            .map(WebUiProgrammeKey::from)
-                            .collect::<HashSet<_>>();
-                        *acc = WebUiChannelAcc {
-                            priority,
-                            channel,
-                            programmes,
-                        };
-                    } else if priority == acc.priority {
-                        for programme in channel.programmes {
-                            let key = WebUiProgrammeKey::from(&programme);
-                            if acc.programmes.insert(key) {
-                                acc.channel.programmes.push(programme);
-                            }
-                        }
-                        acc.channel.programmes.sort_by_key(|programme| programme.start);
-                    }
-                }
-                std::collections::hash_map::Entry::Vacant(entry) => {
-                    let programmes = channel
-                        .programmes
-                        .iter()
-                        .map(WebUiProgrammeKey::from)
-                        .collect::<HashSet<_>>();
-                    entry.insert(WebUiChannelAcc {
-                        priority,
-                        channel,
-                        programmes,
-                    });
-                }
-            }
-        }
-    }
-
-    let mut channels = merged.into_values().map(|entry| entry.channel).collect::<Vec<_>>();
-    channels.sort_by(|left, right| left.id.cmp(&right.id));
-    channels
+fn respond_with_rewritten_epg(app_state: &Arc<AppState>, accept: Option<&str>, epg: Vec<EpgChannel>) -> Response {
+    let config = app_state.app_config.config.load();
+    let web_ui_path = config.web_ui.as_ref().and_then(|w| w.path.as_ref()).map_or("", String::as_str);
+    let resource_url = concat_path_leading_slash(web_ui_path, "api/v1/playlist/resource");
+    let encrypt_secret = app_state.get_encrypt_secret();
+    let epg = epg
+        .into_iter()
+        .map(|channel| rewrite_epg_channel_resource_url(&encrypt_secret, &resource_url, channel))
+        .collect::<Vec<_>>();
+    json_or_bin_response(accept, &epg).into_response()
 }
 
 async fn load_epg_channels_for_input(
@@ -200,25 +148,25 @@ async fn load_epg_channels_for_input(
     };
 
     let storage_dir = app_state.app_config.config.load().storage_dir.clone();
-        let mut channels_by_source = Vec::new();
-        let mut failed_sources = 0usize;
+    let mut channels_by_source = Vec::new();
+    let mut failed_sources = 0usize;
 
-        for epg_source in &epg_config.sources {
-            let resolved_url = resolve_provider_url_with_input(input, &epg_source.url);
-            let raw_epg_path = match get_input_raw_epg_file_path(&resolved_url, input, &storage_dir).await {
-                Ok(path) => path,
-                Err(err) => {
-                    debug!(
-                        "Skipping EPG source {}: {}",
-                        sanitize_sensitive_info(resolved_url.as_str()),
-                        sanitize_sensitive_info(&err.to_string())
-                    );
-                    failed_sources += 1;
-                    continue;
-                }
-            };
+    for epg_source in &epg_config.sources {
+        let resolved_url = resolve_provider_url_with_input(input, &epg_source.url);
+        let raw_epg_path = match get_input_raw_epg_file_path(&resolved_url, input, &storage_dir).await {
+            Ok(path) => path,
+            Err(err) => {
+                debug!(
+                    "Skipping EPG source {}: {}",
+                    sanitize_sensitive_info(resolved_url.as_str()),
+                    sanitize_sensitive_info(&err.to_string())
+                );
+                failed_sources += 1;
+                continue;
+            }
+        };
 
-            let source_channels = if file_exists_async(&raw_epg_path).await {
+        let source_channels = if file_exists_async(&raw_epg_path).await {
             match parse_xmltv_for_web_ui_from_file(&raw_epg_path).await {
                 Ok(ch) => ch,
                 Err(file_err) => {
@@ -229,9 +177,11 @@ async fn load_epg_channels_for_input(
                     match parse_xmltv_for_web_ui_from_url(app_state, &resolved_url).await {
                         Ok(ch) => ch,
                         Err(url_err) => {
-                            debug!("EPG url also failed {}: {}",
+                            debug!(
+                                "EPG url also failed {}: {}",
                                 sanitize_sensitive_info(resolved_url.as_str()),
-                                sanitize_sensitive_info(&url_err.to_string()));
+                                sanitize_sensitive_info(&url_err.to_string())
+                            );
                             failed_sources += 1;
                             continue;
                         }
@@ -242,9 +192,11 @@ async fn load_epg_channels_for_input(
             match parse_xmltv_for_web_ui_from_url(app_state, &resolved_url).await {
                 Ok(ch) => ch,
                 Err(err) => {
-                    debug!("Skipping EPG url {}: {}",
+                    debug!(
+                        "Skipping EPG url {}: {}",
                         sanitize_sensitive_info(resolved_url.as_str()),
-                        sanitize_sensitive_info(&err.to_string()));
+                        sanitize_sensitive_info(&err.to_string())
+                    );
                     failed_sources += 1;
                     continue;
                 }
@@ -312,26 +264,20 @@ async fn playlist_content(
             cluster,
             accept.as_deref(),
         )
-            .await
-            .into_response(),
+        .await
+        .into_response(),
         PlaylistRequest::Input(input_name) => get_playlist_for_input(
             app_state.app_config.get_input_by_name(&input_name.intern()).as_ref(),
             app_state,
             cluster,
             accept.as_deref(),
         )
-            .await
-            .into_response(),
+        .await
+        .into_response(),
         PlaylistRequest::CustomXtream(xtream) => match Url::parse(&xtream.url) {
             Ok(parsed) if parsed.scheme() == "http" || parsed.scheme() == "https" => {
                 let input = Arc::new(create_config_input_for_xtream(&xtream.username, &xtream.password, &xtream.url));
-                get_playlist_for_custom_provider(
-                    client.as_ref(),
-                    Some(&input),
-                    app_state,
-                    cluster,
-                    accept.as_deref(),
-                )
+                get_playlist_for_custom_provider(client.as_ref(), Some(&input), app_state, cluster, accept.as_deref())
                     .await
                     .into_response()
             }
@@ -344,13 +290,7 @@ async fn playlist_content(
         PlaylistRequest::CustomM3u(m3u) => match Url::parse(&m3u.url) {
             Ok(parsed) if parsed.scheme() == "http" || parsed.scheme() == "https" => {
                 let input = Arc::new(create_config_input_for_m3u(&m3u.url));
-                get_playlist_for_custom_provider(
-                    client.as_ref(),
-                    Some(&input),
-                    app_state,
-                    cluster,
-                    accept.as_deref(),
-                )
+                get_playlist_for_custom_provider(client.as_ref(), Some(&input), app_state, cluster, accept.as_deref())
                     .await
                     .into_response()
             }
@@ -397,8 +337,8 @@ async fn playlist_series_info(
                         &virtual_id,
                         XtreamCluster::Series,
                     )
-                        .await
-                        .into_response();
+                    .await
+                    .into_response();
                 }
             }
         }
@@ -459,19 +399,15 @@ async fn playlist_epg(
             if let Some(input) = app_state.app_config.get_input_by_name(&input_name.intern()) {
                 match load_epg_channels_for_input(&app_state, input.as_ref()).await {
                     Ok(Some(epg)) => {
-                        let config = app_state.app_config.config.load();
-                        let web_ui_path = config.web_ui.as_ref().and_then(|w| w.path.as_ref()).map_or("", String::as_str);
-                        let resource_url = concat_path_leading_slash(web_ui_path, "api/v1/playlist/resource");
-                        let encrypt_secret = app_state.get_encrypt_secret();
-                        let epg = epg
-                            .into_iter()
-                            .map(|channel| rewrite_epg_channel_resource_url(&encrypt_secret, &resource_url, channel))
-                            .collect::<Vec<_>>();
-                        return json_or_bin_response(accept.as_deref(), &epg).into_response();
+                        return respond_with_rewritten_epg(&app_state, accept.as_deref(), epg);
                     }
                     Ok(None) => return axum::http::StatusCode::NO_CONTENT.into_response(),
                     Err(err) => {
-                        error!("Failed to load input EPG for '{}': {}", input.name, sanitize_sensitive_info(err.to_string().as_str()));
+                        error!(
+                            "Failed to load input EPG for '{}': {}",
+                            input.name,
+                            sanitize_sensitive_info(err.to_string().as_str())
+                        );
                         return (
                             axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                             axum::Json(serde_json::json!({"error": "Failed to load EPG"})),
@@ -481,29 +417,28 @@ async fn playlist_epg(
                 }
             }
         }
-        PlaylistEpgRequest::Custom(url) => {
-            match parse_xmltv_for_web_ui_from_url(&app_state, &url).await {
-                Ok(epg) => {
-                    let config = app_state.app_config.config.load();
-                    let web_ui_path = config.web_ui.as_ref().and_then(|w| w.path.as_ref()).map_or("", String::as_str);
-                    let resource_url = concat_path_leading_slash(web_ui_path, "api/v1/playlist/resource");
-                    let encrypt_secret = app_state.get_encrypt_secret();
-                    let epg = epg
-                        .into_iter()
-                        .map(|channel| rewrite_epg_channel_resource_url(&encrypt_secret, &resource_url, channel))
-                        .collect::<Vec<_>>();
-                    return json_or_bin_response(accept.as_deref(), &epg).into_response();
-                }
-                Err(err) => {
-                    error!("Failed to load custom EPG: {}", sanitize_sensitive_info(err.to_string().as_str()));
-                    return (
-                        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                        axum::Json(serde_json::json!({"error": "Failed to load EPG"})),
-                    )
-                        .into_response();
+        PlaylistEpgRequest::Custom(url) => match Url::parse(&url) {
+            Ok(parsed) if parsed.scheme() == "http" || parsed.scheme() == "https" => {
+                match parse_xmltv_for_web_ui_from_url(&app_state, &url).await {
+                    Ok(epg) => return respond_with_rewritten_epg(&app_state, accept.as_deref(), epg),
+                    Err(err) => {
+                        error!("Failed to load custom EPG: {}", sanitize_sensitive_info(err.to_string().as_str()));
+                        return (
+                            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                            axum::Json(serde_json::json!({"error": "Failed to load EPG"})),
+                        )
+                            .into_response();
+                    }
                 }
             }
-        }
+            _ => {
+                return (
+                    axum::http::StatusCode::BAD_REQUEST,
+                    axum::Json(json!({"error": "Invalid url scheme; only http/https are allowed"})),
+                )
+                    .into_response();
+            }
+        },
     }
     axum::http::StatusCode::NO_CONTENT.into_response()
 }
@@ -527,13 +462,7 @@ async fn playlist_resolve_url(
 ) -> impl IntoResponse + Send {
     match request {
         PlaylistUrlResolveRequest::Webplayer { target_id, virtual_id, cluster } => {
-            playlist_webplayer(
-                axum::extract::State(app_state),
-                target_id,
-                virtual_id,
-                cluster,
-            )
-                .into_response()
+            playlist_webplayer(axum::extract::State(app_state), target_id, virtual_id, cluster).into_response()
         }
         PlaylistUrlResolveRequest::Provider { playlist_request, url } => {
             resolve_provider_url_for_request(&app_state.app_config, &playlist_request, &url).into_response()
@@ -554,9 +483,7 @@ pub fn v1_api_playlist_register_protected(router: Router<Arc<AppState>>) -> axum
         .route("/playlist/series/episode/{virtual_id}", axum::routing::post(playlist_episode_item))
 }
 
-pub fn v1_api_playlist_register_public(
-    router: Router<Arc<AppState>>,
-) -> axum::Router<Arc<AppState>> {
+pub fn v1_api_playlist_register_public(router: Router<Arc<AppState>>) -> axum::Router<Arc<AppState>> {
     router.route("/playlist/resource/{resource}", axum::routing::get(playlist_resource))
 }
 
@@ -582,11 +509,7 @@ pub fn v1_api_playlist_register_with_permissions(
         .route("/epg/stream", axum::routing::post(stream_epg_api))
         .layer(permission_layer!(app_state, Permission::EpgRead));
 
-    router.nest("/playlist",
-                read_routes
-                    .merge(write_routes)
-                    .merge(epg_routes),
-    )
+    router.nest("/playlist", read_routes.merge(write_routes).merge(epg_routes))
 }
 
 async fn playlist_episode_item(
@@ -618,7 +541,10 @@ mod tests {
             ActiveProviderManager, ActiveUserManager, AppState, ConnectionManager, EventManager, MetadataUpdateManager,
             PlaylistStorageState, SharedStreamManager,
         },
-        model::{AppConfig, Config, ConfigInput, ConfigProvider, ConfigSource, ConfigTarget, SourcesConfig, StreamHistoryConfig},
+        model::{
+            AppConfig, Config, ConfigInput, ConfigProvider, ConfigSource, ConfigTarget, SourcesConfig,
+            StreamHistoryConfig,
+        },
         utils::epg::get_input_raw_epg_file_path,
         utils::GeoIp,
     };
@@ -628,18 +554,21 @@ mod tests {
         http::{Request, StatusCode},
         Router,
     };
+    use chrono::Utc;
     use shared::foundation::Filter;
+    use shared::model::ProcessingOrder;
     use shared::{
-        model::{ConfigPaths, ConfigProviderDto, EpgChannel, EpgConfigDto, EpgProgramme, EpgSourceDto, PlaylistRequest, XtreamCluster},
+        model::{
+            ConfigPaths, ConfigProviderDto, EpgChannel, EpgConfigDto, EpgProgramme, EpgSourceDto, PlaylistRequest,
+            XtreamCluster,
+        },
         utils::Internable,
     };
     use std::sync::Arc;
-    use chrono::Utc;
     use tempfile::tempdir;
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
     use tower::ServiceExt;
-    use shared::model::ProcessingOrder;
 
     /// Generate an XMLTV datetime string in the format `YYYYMMDDHHmmss +0000`
     /// offset by `hours_from_now` hours from the current time.
@@ -822,7 +751,8 @@ mod tests {
         let source = ConfigSource { inputs: vec![Arc::clone(&input.name)], targets: vec![] };
         let app_config = test_app_config(input, source);
         let original = "provider://unknown/live/user/pass/1359.ts";
-        let resolved = resolve_provider_url_for_request(&app_config, &PlaylistRequest::Input("input".to_string()), original);
+        let resolved =
+            resolve_provider_url_for_request(&app_config, &PlaylistRequest::Input("input".to_string()), original);
 
         assert_eq!(resolved, original);
     }
@@ -907,10 +837,8 @@ mod tests {
             watch: None,
             use_memory_cache: false,
         });
-        let source = ConfigSource {
-            inputs: vec![Arc::clone(&input_a.name), Arc::clone(&input_b.name)],
-            targets: vec![target],
-        };
+        let source =
+            ConfigSource { inputs: vec![Arc::clone(&input_a.name), Arc::clone(&input_b.name)], targets: vec![target] };
         let sources = SourcesConfig {
             batch_files: vec![],
             provider: vec![],
@@ -953,7 +881,8 @@ mod tests {
     #[test]
     fn build_playlist_webplayer_url_uses_cluster_stream_type() {
         let live = super::build_playlist_webplayer_url("http://player.example", "token123", 1, 42, XtreamCluster::Live);
-        let movie = super::build_playlist_webplayer_url("http://player.example", "token123", 1, 42, XtreamCluster::Video);
+        let movie =
+            super::build_playlist_webplayer_url("http://player.example", "token123", 1, 42, XtreamCluster::Video);
         let series =
             super::build_playlist_webplayer_url("http://player.example", "token123", 1, 42, XtreamCluster::Series);
 
@@ -963,30 +892,18 @@ mod tests {
     }
 
     #[test]
-    fn merge_epg_channels_prefers_higher_priority_source_and_merges_equal_priority_programmes() {
+    fn merge_epg_channels_prefers_higher_priority_metadata_and_merges_all_programmes() {
         let low_priority = EpgChannel {
             id: "demo.channel".intern(),
             title: Some("Low".intern()),
             icon: Some("http://low/icon.png".intern()),
-            programmes: vec![EpgProgramme::new_all(
-                10,
-                20,
-                "demo.channel".intern(),
-                Some("Low Show".intern()),
-                None,
-            )],
+            programmes: vec![EpgProgramme::new_all(10, 20, "demo.channel".intern(), Some("Low Show".intern()), None)],
         };
         let high_priority = EpgChannel {
             id: "demo.channel".intern(),
             title: Some("High".intern()),
             icon: Some("http://high/icon.png".intern()),
-            programmes: vec![EpgProgramme::new_all(
-                30,
-                40,
-                "demo.channel".intern(),
-                Some("High Show".intern()),
-                None,
-            )],
+            programmes: vec![EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("High Show".intern()), None)],
         };
         let same_priority = EpgChannel {
             id: "demo.channel".intern(),
@@ -998,20 +915,81 @@ mod tests {
             ],
         };
 
-        let channels = super::merge_epg_channels(vec![(10, vec![low_priority]), (0, vec![high_priority]), (0, vec![same_priority])]);
+        let channels = super::merge_epg_channels(vec![
+            (10, vec![low_priority]),
+            (0, vec![high_priority]),
+            (0, vec![same_priority]),
+        ]);
 
         assert_eq!(channels.len(), 1);
         assert_eq!(channels[0].title.as_deref(), Some("High"));
         assert_eq!(channels[0].icon.as_deref(), Some("http://high/icon.png"));
+        assert_eq!(channels[0].programmes.len(), 3);
+        assert_eq!(
+            channels[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
+            vec![(10, 20), (30, 40), (50, 60)],
+        );
+    }
+
+    #[test]
+    fn merge_epg_channels_dedupes_duplicate_programmes_from_winning_source() {
+        let high_priority = EpgChannel {
+            id: "demo.channel".intern(),
+            title: Some("High".intern()),
+            icon: Some("http://high/icon.png".intern()),
+            programmes: vec![
+                EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("High Show".intern()), None),
+                EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("High Show Duplicate".intern()), None),
+            ],
+        };
+        let low_priority = EpgChannel {
+            id: "demo.channel".intern(),
+            title: Some("Low".intern()),
+            icon: Some("http://low/icon.png".intern()),
+            programmes: vec![EpgProgramme::new_all(50, 60, "demo.channel".intern(), Some("Low Show".intern()), None)],
+        };
+
+        let channels = super::merge_epg_channels(vec![(0, vec![high_priority]), (10, vec![low_priority])]);
+
+        assert_eq!(channels.len(), 1);
         assert_eq!(channels[0].programmes.len(), 2);
         assert_eq!(
-            channels[0]
-                .programmes
-                .iter()
-                .map(|programme| (programme.start, programme.stop))
-                .collect::<Vec<_>>(),
+            channels[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
             vec![(30, 40), (50, 60)],
         );
+        assert_eq!(channels[0].programmes[0].title.as_deref(), Some("High Show"));
+    }
+
+    #[tokio::test]
+    async fn playlist_epg_custom_route_rejects_invalid_url_scheme() {
+        let provider = ConfigProvider::from(&ConfigProviderDto {
+            name: "demo".intern(),
+            urls: vec!["http://provider.example".intern()],
+            provider_url_selection_policy: shared::model::ProviderUrlSelectionPolicy::default(),
+            dns: None,
+        });
+        let input = Arc::new(ConfigInput {
+            id: 7,
+            name: "input".intern(),
+            provider_configs: Some(vec![Arc::new(provider)]),
+            ..Default::default()
+        });
+        let source = ConfigSource { inputs: vec![Arc::clone(&input.name)], targets: vec![] };
+        let app_state = test_app_state(Arc::new(test_app_config(input, source)));
+        let router = super::v1_api_playlist_register_protected(Router::new()).with_state(app_state);
+        let request = Request::builder()
+            .method("POST")
+            .uri("/playlist/epg")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"Custom":"file:///tmp/epg.xml"}"#))
+            .expect("request");
+
+        let response = router.into_service::<Body>().oneshot(request).await.expect("response");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.expect("body");
+        let body_text = String::from_utf8(body.to_vec()).expect("utf8");
+        assert!(body_text.contains("Invalid url scheme"), "{body_text}");
     }
 
     #[tokio::test]
@@ -1042,10 +1020,7 @@ mod tests {
             provider_configs: Some(vec![Arc::new(provider)]),
             ..Default::default()
         });
-        let source = ConfigSource {
-            inputs: vec![Arc::clone(&input.name)],
-            targets: vec![],
-        };
+        let source = ConfigSource { inputs: vec![Arc::clone(&input.name)], targets: vec![] };
         let app_config = test_app_config(input.clone(), source);
         app_config.config.store(Arc::new(Config {
             storage_dir: temp_dir.path().to_string_lossy().to_string(),
@@ -1056,8 +1031,8 @@ mod tests {
             input.as_ref(),
             temp_dir.path().to_string_lossy().as_ref(),
         )
-            .await
-            .expect("epg path");
+        .await
+        .expect("epg path");
         if let Some(parent) = raw_epg_path.parent() {
             tokio::fs::create_dir_all(parent).await.expect("epg dir");
         }
@@ -1077,22 +1052,17 @@ mod tests {
 </tv>"#
             ),
         )
-            .await
-            .expect("write epg");
+        .await
+        .expect("write epg");
 
         let app_state = test_app_state(Arc::new(app_config));
-        let channels = super::load_epg_channels_for_input(&app_state, input.as_ref())
-            .await
-            .expect("load epg")
-            .expect("channels");
+        let channels =
+            super::load_epg_channels_for_input(&app_state, input.as_ref()).await.expect("load epg").expect("channels");
 
         assert_eq!(channels.len(), 1);
         assert_eq!(channels[0].id.as_ref(), "demo.channel");
         assert_eq!(channels[0].programmes.len(), 1);
-        assert_eq!(
-            channels[0].programmes[0].title.as_ref().map(std::convert::AsRef::as_ref),
-            Some("Morning Show")
-        );
+        assert_eq!(channels[0].programmes[0].title.as_ref().map(std::convert::AsRef::as_ref), Some("Morning Show"));
     }
 
     #[tokio::test]
@@ -1123,10 +1093,7 @@ mod tests {
             provider_configs: Some(vec![Arc::new(provider)]),
             ..Default::default()
         });
-        let source = ConfigSource {
-            inputs: vec![Arc::clone(&input.name)],
-            targets: vec![],
-        };
+        let source = ConfigSource { inputs: vec![Arc::clone(&input.name)], targets: vec![] };
         let app_config = test_app_config(input.clone(), source);
         app_config.config.store(Arc::new(Config {
             storage_dir: temp_dir.path().to_string_lossy().to_string(),
@@ -1137,8 +1104,8 @@ mod tests {
             input.as_ref(),
             temp_dir.path().to_string_lossy().as_ref(),
         )
-            .await
-            .expect("epg path");
+        .await
+        .expect("epg path");
         if let Some(parent) = raw_epg_path.parent() {
             tokio::fs::create_dir_all(parent).await.expect("epg dir");
         }
@@ -1158,8 +1125,8 @@ mod tests {
 </tv>"#
             ),
         )
-            .await
-            .expect("write epg");
+        .await
+        .expect("write epg");
 
         let app_state = test_app_state(Arc::new(app_config));
         let router = super::v1_api_playlist_register_protected(Router::new()).with_state(app_state);
@@ -1193,10 +1160,7 @@ mod tests {
             provider_configs: Some(vec![Arc::new(provider)]),
             ..Default::default()
         });
-        let source = ConfigSource {
-            inputs: vec![Arc::clone(&input.name)],
-            targets: vec![],
-        };
+        let source = ConfigSource { inputs: vec![Arc::clone(&input.name)], targets: vec![] };
         let app_state = test_app_state(Arc::new(test_app_config(input, source)));
         let router = super::v1_api_playlist_register_protected(Router::new()).with_state(app_state);
         let request = Request::builder()
@@ -1228,16 +1192,8 @@ mod tests {
             name: "input".intern(),
             epg: Some(crate::model::EpgConfig::from(&EpgConfigDto {
                 sources: Some(vec![
-                    EpgSourceDto {
-                        url: secondary_url.to_string(),
-                        priority: 10,
-                        logo_override: false,
-                    },
-                    EpgSourceDto {
-                        url: primary_url.to_string(),
-                        priority: 0,
-                        logo_override: false,
-                    },
+                    EpgSourceDto { url: secondary_url.to_string(), priority: 10, logo_override: false },
+                    EpgSourceDto { url: primary_url.to_string(), priority: 0, logo_override: false },
                     EpgSourceDto {
                         url: "provider://demo/xmltv-same-priority.php?username=user&password=pass".to_string(),
                         priority: 0,
@@ -1245,16 +1201,8 @@ mod tests {
                     },
                 ]),
                 t_sources: vec![
-                    EpgSourceDto {
-                        url: secondary_url.to_string(),
-                        priority: 10,
-                        logo_override: false,
-                    },
-                    EpgSourceDto {
-                        url: primary_url.to_string(),
-                        priority: 0,
-                        logo_override: false,
-                    },
+                    EpgSourceDto { url: secondary_url.to_string(), priority: 10, logo_override: false },
+                    EpgSourceDto { url: primary_url.to_string(), priority: 0, logo_override: false },
                     EpgSourceDto {
                         url: "provider://demo/xmltv-same-priority.php?username=user&password=pass".to_string(),
                         priority: 0,
@@ -1266,10 +1214,7 @@ mod tests {
             provider_configs: Some(vec![Arc::new(provider)]),
             ..Default::default()
         });
-        let source = ConfigSource {
-            inputs: vec![Arc::clone(&input.name)],
-            targets: vec![],
-        };
+        let source = ConfigSource { inputs: vec![Arc::clone(&input.name)], targets: vec![] };
         let app_config = test_app_config(input.clone(), source);
         app_config.config.store(Arc::new(Config {
             storage_dir: temp_dir.path().to_string_lossy().to_string(),
@@ -1281,22 +1226,22 @@ mod tests {
             input.as_ref(),
             temp_dir.path().to_string_lossy().as_ref(),
         )
-            .await
-            .expect("primary epg path");
+        .await
+        .expect("primary epg path");
         let secondary_path = get_input_raw_epg_file_path(
             "http://provider.example/xmltv-secondary.php?username=user&password=pass",
             input.as_ref(),
             temp_dir.path().to_string_lossy().as_ref(),
         )
-            .await
-            .expect("secondary epg path");
+        .await
+        .expect("secondary epg path");
         let same_priority_path = get_input_raw_epg_file_path(
             "http://provider.example/xmltv-same-priority.php?username=user&password=pass",
             input.as_ref(),
             temp_dir.path().to_string_lossy().as_ref(),
         )
-            .await
-            .expect("same priority epg path");
+        .await
+        .expect("same priority epg path");
 
         for path in [&primary_path, &secondary_path, &same_priority_path] {
             if let Some(parent) = path.parent() {
@@ -1324,8 +1269,8 @@ mod tests {
 </tv>"#
             ),
         )
-            .await
-            .expect("write secondary epg");
+        .await
+        .expect("write secondary epg");
         tokio::fs::write(
             &primary_path,
             format!(
@@ -1341,8 +1286,8 @@ mod tests {
 </tv>"#
             ),
         )
-            .await
-            .expect("write primary epg");
+        .await
+        .expect("write primary epg");
         tokio::fs::write(
             &same_priority_path,
             format!(
@@ -1361,8 +1306,8 @@ mod tests {
 </tv>"#
             ),
         )
-            .await
-            .expect("write same priority epg");
+        .await
+        .expect("write same priority epg");
 
         let app_state = test_app_state(Arc::new(app_config));
         let router = super::v1_api_playlist_register_protected(Router::new()).with_state(app_state);
@@ -1384,5 +1329,4 @@ mod tests {
         assert!(body_text.contains("Second Show"), "{body_text}");
         assert!(!body_text.contains("Secondary Show"), "{body_text}");
     }
-
 }

--- a/backend/src/api/endpoints/v1_api_playlist.rs
+++ b/backend/src/api/endpoints/v1_api_playlist.rs
@@ -123,10 +123,6 @@ fn build_playlist_webplayer_url(
     format!("{base_url}/token/{access_token}/{}/{}/{}", target_id, cluster.as_stream_type(), virtual_id)
 }
 
-fn merge_epg_channels(channels_by_source: Vec<(i16, Vec<EpgChannel>)>) -> Vec<EpgChannel> {
-    merge_prioritized_channels(channels_by_source)
-}
-
 fn respond_with_rewritten_epg(app_state: &Arc<AppState>, accept: Option<&str>, epg: Vec<EpgChannel>) -> Response {
     let config = app_state.app_config.config.load();
     let web_ui_path = config.web_ui.as_ref().and_then(|w| w.path.as_ref()).map_or("", String::as_str);
@@ -215,7 +211,7 @@ async fn load_epg_channels_for_input(
             Ok(None)
         }
     } else {
-        Ok(Some(merge_epg_channels(channels_by_source)))
+        Ok(Some(merge_prioritized_channels(channels_by_source)))
     }
 }
 
@@ -558,10 +554,7 @@ mod tests {
     use shared::foundation::Filter;
     use shared::model::ProcessingOrder;
     use shared::{
-        model::{
-            ConfigPaths, ConfigProviderDto, EpgChannel, EpgConfigDto, EpgProgramme, EpgSourceDto, PlaylistRequest,
-            XtreamCluster,
-        },
+        model::{ConfigPaths, ConfigProviderDto, EpgConfigDto, EpgSourceDto, PlaylistRequest, XtreamCluster},
         utils::Internable,
     };
     use std::sync::Arc;
@@ -889,75 +882,6 @@ mod tests {
         assert_eq!(live, "http://player.example/token/token123/1/live/42");
         assert_eq!(movie, "http://player.example/token/token123/1/movie/42");
         assert_eq!(series, "http://player.example/token/token123/1/series/42");
-    }
-
-    #[test]
-    fn merge_epg_channels_prefers_higher_priority_metadata_and_merges_all_programmes() {
-        let low_priority = EpgChannel {
-            id: "demo.channel".intern(),
-            title: Some("Low".intern()),
-            icon: Some("http://low/icon.png".intern()),
-            programmes: vec![EpgProgramme::new_all(10, 20, "demo.channel".intern(), Some("Low Show".intern()), None)],
-        };
-        let high_priority = EpgChannel {
-            id: "demo.channel".intern(),
-            title: Some("High".intern()),
-            icon: Some("http://high/icon.png".intern()),
-            programmes: vec![EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("High Show".intern()), None)],
-        };
-        let same_priority = EpgChannel {
-            id: "demo.channel".intern(),
-            title: Some("Same".intern()),
-            icon: Some("http://same/icon.png".intern()),
-            programmes: vec![
-                EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("Duplicate".intern()), None),
-                EpgProgramme::new_all(50, 60, "demo.channel".intern(), Some("Second Show".intern()), None),
-            ],
-        };
-
-        let channels = super::merge_epg_channels(vec![
-            (10, vec![low_priority]),
-            (0, vec![high_priority]),
-            (0, vec![same_priority]),
-        ]);
-
-        assert_eq!(channels.len(), 1);
-        assert_eq!(channels[0].title.as_deref(), Some("High"));
-        assert_eq!(channels[0].icon.as_deref(), Some("http://high/icon.png"));
-        assert_eq!(channels[0].programmes.len(), 3);
-        assert_eq!(
-            channels[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
-            vec![(10, 20), (30, 40), (50, 60)],
-        );
-    }
-
-    #[test]
-    fn merge_epg_channels_dedupes_duplicate_programmes_from_winning_source() {
-        let high_priority = EpgChannel {
-            id: "demo.channel".intern(),
-            title: Some("High".intern()),
-            icon: Some("http://high/icon.png".intern()),
-            programmes: vec![
-                EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("High Show".intern()), None),
-                EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("High Show Duplicate".intern()), None),
-            ],
-        };
-        let low_priority = EpgChannel {
-            id: "demo.channel".intern(),
-            title: Some("Low".intern()),
-            icon: Some("http://low/icon.png".intern()),
-            programmes: vec![EpgProgramme::new_all(50, 60, "demo.channel".intern(), Some("Low Show".intern()), None)],
-        };
-
-        let channels = super::merge_epg_channels(vec![(0, vec![high_priority]), (10, vec![low_priority])]);
-
-        assert_eq!(channels.len(), 1);
-        assert_eq!(channels[0].programmes.len(), 2);
-        assert_eq!(
-            channels[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
-            vec![(30, 40), (50, 60)],
-        );
-        assert_eq!(channels[0].programmes[0].title.as_deref(), Some("High Show"));
     }
 
     #[tokio::test]

--- a/backend/src/processing/parser/xmltv.rs
+++ b/backend/src/processing/parser/xmltv.rs
@@ -1,8 +1,11 @@
-use crate::model::{Epg, TVGuide, XmlTag, XmlTagIcon, EPG_ATTRIB_CHANNEL, EPG_ATTRIB_ID, EPG_TAG_CHANNEL, EPG_TAG_DISPLAY_NAME, EPG_TAG_ICON, EPG_TAG_PROGRAMME, EPG_TAG_TV};
+use crate::model::{
+    Epg, TVGuide, XmlTag, XmlTagIcon, EPG_ATTRIB_CHANNEL, EPG_ATTRIB_ID, EPG_TAG_CHANNEL, EPG_TAG_DISPLAY_NAME,
+    EPG_TAG_ICON, EPG_TAG_PROGRAMME, EPG_TAG_TV,
+};
 use crate::model::{EpgSmartMatchConfig, PersistedEpgSource};
 use crate::processing::processor::EpgIdCache;
 use crate::utils::compressed_file_reader_async::CompressedFileReaderAsync;
-use crate::utils::{async_file_reader, parse_xmltv_time};
+use crate::utils::{async_file_reader, merge_prioritized_channels, parse_xmltv_time};
 use log::error;
 use quick_xml::events::{BytesStart, BytesText, Event};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
@@ -49,7 +52,6 @@ fn split_by_first_match<'a>(input: &'a str, delimiters: &[char]) -> (Option<&'a 
     (None, input)
 }
 
-
 fn name_prefix<'a>(name: &'a str, smart_config: &EpgSmartMatchConfig) -> (&'a str, Option<&'a str>) {
     if smart_config.name_prefix != EpgNamePrefix::Ignore {
         let (prefix, suffix) = split_by_first_match(name, &smart_config.name_prefix_separator);
@@ -75,43 +77,45 @@ pub fn normalize_channel_name(name: &str, normalize_config: &EpgSmartMatchConfig
     // Remove all non-alphanumeric characters (except dashes and underscores).
     let cleaned_name = normalize_config.normalize_regex.replace_all(channel_name, "");
     // Remove terms like resolution
-    let cleaned_name = normalize_config.strip.iter().fold(cleaned_name.to_string(), |acc, term| {
-        acc.replace(term, "")
-    });
+    let cleaned_name = normalize_config.strip.iter().fold(cleaned_name.to_string(), |acc, term| acc.replace(term, ""));
     match suffix {
         None => cleaned_name,
-        Some(sfx) => {
-            match &normalize_config.name_prefix {
-                EpgNamePrefix::Ignore => cleaned_name,
-                EpgNamePrefix::Suffix(sep) => combine(sep, &cleaned_name, sfx),
-                EpgNamePrefix::Prefix(sep) => combine(sep, sfx, &cleaned_name),
-            }
-        }
+        Some(sfx) => match &normalize_config.name_prefix {
+            EpgNamePrefix::Ignore => cleaned_name,
+            EpgNamePrefix::Suffix(sep) => combine(sep, &cleaned_name, sfx),
+            EpgNamePrefix::Prefix(sep) => combine(sep, sfx, &cleaned_name),
+        },
     }
 }
 
-
 impl TVGuide {
     pub fn merge(epgs: Vec<Epg>) -> Option<Epg> {
-        if let Some(first_epg) = epgs.first() {
-            let first_epg_attributes = first_epg.attributes.clone();
-            let merged_children: Vec<Arc<EpgChannel>> = epgs.into_iter().flat_map(|epg| epg.children).collect();
-            Some(Epg {
-                logo_override: false,
-                priority: 0,
-                attributes: first_epg_attributes,
-                children: merged_children,
-            })
-        } else {
-            None
+        if epgs.is_empty() {
+            return None;
         }
+
+        let epg_attributes = epgs.iter().min_by_key(|epg| epg.priority).and_then(|epg| epg.attributes.clone());
+
+        let mut channels_by_source = Vec::with_capacity(epgs.len());
+        for epg in epgs {
+            let mut source_channels = Vec::with_capacity(epg.children.len());
+            for channel_arc in epg.children {
+                let Ok(channel) = Arc::try_unwrap(channel_arc) else {
+                    error!("Failed to unwrap epg channel");
+                    continue;
+                };
+                source_channels.push(channel);
+            }
+            channels_by_source.push((epg.priority, source_channels));
+        }
+
+        let children = merge_prioritized_channels(channels_by_source).into_iter().map(Arc::new).collect();
+        Some(Epg { logo_override: false, priority: 0, attributes: epg_attributes, children })
     }
 
     fn prepare_tag(id_cache: &mut EpgIdCache, tag: &mut XmlTag, smart_match: bool) {
         {
-            let maybe_epg_id = {
-                tag.get_attribute_value(&EPG_ATTRIB_ID.intern()).cloned()
-            };
+            let maybe_epg_id = { tag.get_attribute_value(&EPG_ATTRIB_ID.intern()).cloned() };
             if let Some(epg_id) = maybe_epg_id {
                 tag.normalized_epg_ids
                     .get_or_insert_with(Vec::new)
@@ -124,11 +128,11 @@ impl TVGuide {
             for child in children {
                 match child.name.as_ref() {
                     EPG_TAG_DISPLAY_NAME if smart_match => {
-                            if let Some(name) = &child.value {
-                                tag.normalized_epg_ids
-                                    .get_or_insert_with(Vec::new)
-                                    .push(normalize_channel_name(name, &id_cache.smart_match_config).intern());
-                            }
+                        if let Some(name) = &child.value {
+                            tag.normalized_epg_ids
+                                .get_or_insert_with(Vec::new)
+                                .push(normalize_channel_name(name, &id_cache.smart_match_config).intern());
+                        }
                     }
                     EPG_TAG_ICON => {
                         if let Some(src) = child.get_attribute_value(&src) {
@@ -146,10 +150,8 @@ impl TVGuide {
     }
 
     fn try_fuzzy_matching(id_cache: &mut EpgIdCache, epg_id: &Arc<str>, tag: &XmlTag, fuzzy_matching: bool) -> bool {
-        let mut matched = tag
-            .normalized_epg_ids
-            .as_ref()
-            .is_some_and(|ids| id_cache.match_with_normalized(epg_id, ids));
+        let mut matched =
+            tag.normalized_epg_ids.as_ref().is_some_and(|ids| id_cache.match_with_normalized(epg_id, ids));
         if !matched && fuzzy_matching {
             let (fuzzy_matched, matched_normalized_name) = Self::find_best_fuzzy_match(id_cache, tag);
             if fuzzy_matched {
@@ -163,6 +165,112 @@ impl TVGuide {
             }
         }
         matched
+    }
+
+    fn channel_display_name(tag: &XmlTag) -> Option<Arc<str>> {
+        tag.children.as_ref().and_then(|children| {
+            children.iter().find(|c| c.name.as_ref() == EPG_TAG_DISPLAY_NAME).and_then(|c| c.value.clone())
+        })
+    }
+
+    fn channel_icon(tag: &XmlTag) -> Option<Arc<str>> {
+        if let XmlTagIcon::Src(src) = &tag.icon {
+            Some(Arc::clone(src))
+        } else {
+            None
+        }
+    }
+
+    fn add_channel_tag(
+        id_cache: &mut EpgIdCache,
+        source_processed: &mut HashSet<Arc<str>>,
+        children: &mut HashMap<Arc<str>, EpgChannel>,
+        tag: &mut XmlTag,
+        smart_match: bool,
+        fuzzy_matching: bool,
+    ) {
+        let tag_epg_id =
+            tag.get_attribute_value(&EPG_ATTRIB_ID.intern()).map_or_else(|| "".intern(), Internable::intern);
+        if tag_epg_id.is_empty() {
+            return;
+        }
+
+        Self::prepare_tag(id_cache, tag, smart_match);
+        let add_channel = if smart_match {
+            Self::try_fuzzy_matching(id_cache, &tag_epg_id, tag, fuzzy_matching)
+        } else {
+            id_cache.channel_epg_id.contains(&tag_epg_id)
+        };
+
+        if !add_channel {
+            return;
+        }
+
+        if source_processed.contains(&tag_epg_id) {
+            if let Some(channel) = children.get_mut(&tag_epg_id) {
+                if channel.title.is_none() {
+                    channel.title = Self::channel_display_name(tag);
+                }
+                if channel.icon.is_none() {
+                    channel.icon = Self::channel_icon(tag);
+                }
+            }
+            id_cache.processed.insert(tag_epg_id);
+            return;
+        }
+
+        children.insert(
+            Arc::clone(&tag_epg_id),
+            EpgChannel {
+                id: Arc::clone(&tag_epg_id),
+                title: Self::channel_display_name(tag),
+                icon: Self::channel_icon(tag),
+                programmes: vec![],
+            },
+        );
+        source_processed.insert(Arc::clone(&tag_epg_id));
+        id_cache.processed.insert(tag_epg_id);
+    }
+
+    fn add_programme_tag(
+        children: &mut HashMap<Arc<str>, EpgChannel>,
+        tag: &XmlTag,
+        epg_id: &Arc<str>,
+        start_attrib: &Arc<str>,
+        stop_attrib: &Arc<str>,
+        tag_title: &Arc<str>,
+        tag_desc: &Arc<str>,
+    ) {
+        let Some(channel) = children.get_mut(epg_id) else {
+            error!("Channel {epg_id} not found in EPG, dangling programme");
+            return;
+        };
+
+        let Some((Some(start), Some(stop))) =
+            tag.attributes.as_ref().map(|a| (a.get(start_attrib), a.get(stop_attrib)))
+        else {
+            error!("Missing start or stop attribute in programme tag, skipping");
+            return;
+        };
+
+        let (Some(start_time), Some(stop_time)) = (parse_xmltv_time(start), parse_xmltv_time(stop)) else {
+            error!("Failed to parse epg programme time {start} - {stop}");
+            return;
+        };
+
+        let mut title = None;
+        let mut desc = None;
+        if let Some(children) = tag.children.as_ref() {
+            for child in children {
+                if child.name == *tag_title {
+                    title.clone_from(&child.value);
+                } else if child.name == *tag_desc {
+                    desc.clone_from(&child.value);
+                }
+            }
+        }
+
+        channel.programmes.push(EpgProgramme::new_all(start_time, stop_time, Arc::clone(epg_id), title, desc));
     }
 
     /// Finds the best fuzzy match for a channel's normalized EPG ID using phonetic encoding and Jaro-Winkler similarity.
@@ -192,10 +300,8 @@ impl TVGuide {
         };
 
         // 1) Precalculation: (tag_normalized, tag_code)
-        let pre: Vec<(Arc<str>, Arc<str>)> = normalized_epg_ids
-            .iter()
-            .map(|tn| (tn.clone(), id_cache.phonetic(tn)))
-            .collect();
+        let pre: Vec<(Arc<str>, Arc<str>)> =
+            normalized_epg_ids.iter().map(|tn| (tn.clone(), id_cache.phonetic(tn))).collect();
 
         // 2) Early exit if match >= best_match_threshold
         for (tag_normalized, tag_code) in &pre {
@@ -254,7 +360,6 @@ impl TVGuide {
     /// }
     /// ```
     async fn process_epg_file(id_cache: &mut EpgIdCache, epg_source: &PersistedEpgSource) -> Option<Epg> {
-        let epg_attrib_id = EPG_ATTRIB_ID.intern();
         let epg_attrib_channel = EPG_ATTRIB_CHANNEL.intern();
         let start_attrib = "start".intern();
         let stop_attrib = "stop".intern();
@@ -264,75 +369,38 @@ impl TVGuide {
         match CompressedFileReaderAsync::new(&epg_source.file_path).await {
             Ok(mut reader) => {
                 let mut children: HashMap<Arc<str>, EpgChannel> = HashMap::with_capacity(5000);
+                let mut source_processed: HashSet<Arc<str>> = HashSet::with_capacity(5000);
                 let mut tv_attributes: Option<HashMap<Arc<str>, Arc<str>>> = None;
                 let smart_match = id_cache.smart_match_config.enabled;
                 let fuzzy_matching = smart_match && id_cache.smart_match_config.fuzzy_matching;
-                let mut filter_tags = |mut tag: XmlTag| {
-                    match tag.name.as_ref() {
-                        EPG_TAG_CHANNEL => {
-                            let tag_epg_id = tag.get_attribute_value(&epg_attrib_id).map_or_else(|| "".intern(), Internable::intern);
-                            if !tag_epg_id.is_empty() && !id_cache.processed.contains(&tag_epg_id) {
-                                Self::prepare_tag(id_cache, &mut tag, smart_match);
-                                let mut add_channel = false;
-                                if smart_match {
-                                    if Self::try_fuzzy_matching(id_cache, &tag_epg_id, &tag, fuzzy_matching) {
-                                        add_channel = true;
-                                    }
-                                } else if id_cache.channel_epg_id.contains(&tag_epg_id) {
-                                    add_channel = true;
-                                }
-
-                                if add_channel && !children.contains_key(&tag_epg_id) {
-                                    let display_name = tag.children.as_ref().and_then(|children| {
-                                        children.iter()
-                                            .find(|c| c.name.as_ref() == EPG_TAG_DISPLAY_NAME)
-                                            .and_then(|c| c.value.clone())
-                                    });
-                                    children.insert(Arc::clone(&tag_epg_id), EpgChannel {
-                                        id: Arc::clone(&tag_epg_id),
-                                        title: display_name,
-                                        icon: if let XmlTagIcon::Src(src) = &tag.icon { Some(Arc::clone(src)) } else { None },
-                                        programmes: vec![],
-                                    });
-                                    id_cache.processed.insert(tag_epg_id);
-                                }
+                let mut filter_tags = |mut tag: XmlTag| match tag.name.as_ref() {
+                    EPG_TAG_CHANNEL => Self::add_channel_tag(
+                        id_cache,
+                        &mut source_processed,
+                        &mut children,
+                        &mut tag,
+                        smart_match,
+                        fuzzy_matching,
+                    ),
+                    EPG_TAG_PROGRAMME => {
+                        if let Some(epg_id) = tag.get_attribute_value(&epg_attrib_channel) {
+                            if source_processed.contains(epg_id) {
+                                Self::add_programme_tag(
+                                    &mut children,
+                                    &tag,
+                                    epg_id,
+                                    &start_attrib,
+                                    &stop_attrib,
+                                    &tag_title,
+                                    &tag_desc,
+                                );
                             }
                         }
-                        EPG_TAG_PROGRAMME => {
-                            if let Some(epg_id) = tag.get_attribute_value(&epg_attrib_channel) {
-                                if id_cache.processed.contains(epg_id) /*&& id_cache.channel_epg_id.contains(epg_id) */{
-                                    if let Some(channel) = children.get_mut(epg_id) {
-                                        if let Some((Some(start), Some(stop))) = tag.attributes.as_ref().map(|a| (a.get(&start_attrib), a.get(&stop_attrib))) {
-                                            if let (Some(start_time), Some(stop_time)) = (parse_xmltv_time(start), parse_xmltv_time(stop)) {
-                                                let mut title = None;
-                                                let mut desc = None;
-                                                if let Some(children) = tag.children.as_ref() {
-                                                    for child in children {
-                                                        if child.name == tag_title {
-                                                            title.clone_from(&child.value);
-                                                        } else if child.name == tag_desc {
-                                                            desc.clone_from(&child.value);
-                                                        }
-                                                    }
-                                                    channel.programmes.push(EpgProgramme::new_all(start_time, stop_time, Arc::clone(epg_id), title, desc));
-                                                }
-                                            } else {
-                                                error!("Failed to parse epg programme time {start} - {stop}");
-                                            }
-                                        } else {
-                                            error!("Missing start or stop attribute in programme tag, skipping");
-                                        }
-                                    } else {
-                                        error!("Channel {epg_id} not found in EPG, dangling programme");
-                                    }
-                                }
-                            }
-                        }
-                        EPG_TAG_TV => {
-                            tv_attributes.clone_from(&tag.attributes);
-                        }
-                        _ => {}
                     }
+                    EPG_TAG_TV => {
+                        tv_attributes.clone_from(&tag.attributes);
+                    }
+                    _ => {}
                 };
 
                 parse_tvguide(&mut reader, &mut filter_tags).await;
@@ -494,12 +562,14 @@ fn get_tag_type(name: &str) -> XmlTagType {
         EPG_TAG_TV => XmlTagType::Tv,
         EPG_TAG_CHANNEL => XmlTagType::Channel,
         EPG_TAG_PROGRAMME => XmlTagType::Programme,
-        _ => XmlTagType::Ignored
+        _ => XmlTagType::Ignored,
     }
 }
 
 fn collect_tag_attributes(e: &BytesStart, tag_type: XmlTagType) -> HashMap<Arc<str>, Arc<str>> {
-    let attributes = e.attributes().filter_map(Result::ok)
+    let attributes = e
+        .attributes()
+        .filter_map(Result::ok)
         .filter_map(|a| {
             let key_binding = a.key;
             let key_raw = String::from_utf8_lossy(key_binding.as_ref());
@@ -507,7 +577,9 @@ fn collect_tag_attributes(e: &BytesStart, tag_type: XmlTagType) -> HashMap<Arc<s
             if let Ok(value) = a.unescape_value().as_ref() {
                 if value.is_empty() {
                     None
-                } else if (tag_type.is_channel() && key.as_ref() == EPG_ATTRIB_ID) || (tag_type.is_program() && key.as_ref() == EPG_ATTRIB_CHANNEL) {
+                } else if (tag_type.is_channel() && key.as_ref() == EPG_ATTRIB_ID)
+                    || (tag_type.is_program() && key.as_ref() == EPG_ATTRIB_CHANNEL)
+                {
                     Some((key, value.to_lowercase().intern()))
                 } else {
                     Some((key, value.intern()))
@@ -515,29 +587,9 @@ fn collect_tag_attributes(e: &BytesStart, tag_type: XmlTagType) -> HashMap<Arc<s
             } else {
                 None
             }
-        }).collect::<HashMap<Arc<str>, Arc<str>>>();
+        })
+        .collect::<HashMap<Arc<str>, Arc<str>>>();
     attributes
-}
-
-#[derive(Hash, Eq, PartialEq)]
-struct ProgrammeKey {
-    start: i64,
-    stop: i64,
-}
-
-impl From<&EpgProgramme> for ProgrammeKey {
-    fn from(p: &EpgProgramme) -> Self {
-        Self {
-            start: p.start,
-            stop: p.stop,
-        }
-    }
-}
-
-struct ChannelAcc {
-    priority: i16,
-    channel: EpgChannel,
-    programmes: HashSet<ProgrammeKey>,
 }
 
 pub fn flatten_tvguide(mut tv_guides: Vec<Epg>) -> Option<Epg> {
@@ -545,77 +597,36 @@ pub fn flatten_tvguide(mut tv_guides: Vec<Epg>) -> Option<Epg> {
         return None;
     }
 
-    let epg_attributes = tv_guides
-        .first()
-        .and_then(|t| t.attributes.clone());
-
-    let mut channels: HashMap<Arc<str>, ChannelAcc> = HashMap::new();
+    let epg_attributes = tv_guides.iter().min_by_key(|guide| guide.priority).and_then(|guide| guide.attributes.clone());
+    let mut channels_by_source = Vec::with_capacity(tv_guides.len());
 
     for guide in tv_guides.drain(..) {
+        let mut source_channels = Vec::with_capacity(guide.children.len());
         for channel_arc in guide.children {
-            let Ok(mut channel) = Arc::try_unwrap(channel_arc) else {
+            let Ok(channel) = Arc::try_unwrap(channel_arc) else {
                 error!("Failed to unwrap epg channel");
                 continue;
             };
-            match channels.entry(Arc::clone(&channel.id)) {
-                std::collections::hash_map::Entry::Occupied(mut entry) => {
-                    let acc = entry.get_mut();
-
-                    if guide.priority < acc.priority {
-                        // high priority
-                        acc.priority = guide.priority;
-                        acc.channel = channel;
-
-                        acc.programmes.clear();
-                        for p in &acc.channel.programmes {
-                            acc.programmes.insert(ProgrammeKey::from(p));
-                        }
-                    } else if guide.priority == acc.priority {
-                        // same priority -> merge
-                        for p in channel.programmes.drain(..) {
-                            let key = ProgrammeKey::from(&p);
-                            if acc.programmes.insert(key) {
-                                acc.channel.programmes.push(p);
-                            }
-                        }
-                    }
-                }
-
-                std::collections::hash_map::Entry::Vacant(entry) => {
-                    let mut set = HashSet::new();
-                    for p in &channel.programmes {
-                        set.insert(ProgrammeKey::from(p));
-                    }
-
-                    entry.insert(ChannelAcc {
-                        priority: guide.priority,
-                        channel,
-                        programmes: set,
-                    });
-                }
-            }
+            source_channels.push(channel);
         }
+        channels_by_source.push((guide.priority, source_channels));
     }
 
-    let children = channels
-        .into_values()
-        .map(|acc| Arc::new(acc.channel))
-        .collect();
+    let children = merge_prioritized_channels(channels_by_source).into_iter().map(Arc::new).collect();
 
-    Some(Epg {
-        logo_override: false,
-        priority: 0,
-        attributes: epg_attributes,
-        children,
-    })
+    Some(Epg { logo_override: false, priority: 0, attributes: epg_attributes, children })
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::model::{EpgSmartMatchConfig, PersistedEpgSource, TVGuide};
+    use crate::model::{Epg, EpgSmartMatchConfig, PersistedEpgSource, TVGuide};
     use crate::processing::parser::xmltv::normalize_channel_name;
-    use std::collections::HashSet;
+    use shared::model::{EpgChannel, EpgProgramme};
+    use std::collections::{HashMap, HashSet};
+    use std::fs;
     use std::path::PathBuf;
+    use std::sync::Arc;
+    use tempfile::tempdir;
 
     #[test]
     /// Tests normalization of a channel name using the default smart match configuration.
@@ -632,6 +643,327 @@ mod tests {
         assert_eq!(normalized, "lovenature".to_string());
     }
 
+    #[test]
+    fn flatten_tvguide_prefers_higher_priority_metadata_and_merges_all_programmes() {
+        let low_priority = Epg {
+            logo_override: false,
+            priority: 10,
+            attributes: None,
+            children: vec![Arc::new(EpgChannel {
+                id: "demo.channel".intern(),
+                title: Some("Low".intern()),
+                icon: Some("http://low/icon.png".intern()),
+                programmes: vec![EpgProgramme::new_all(
+                    10,
+                    20,
+                    "demo.channel".intern(),
+                    Some("Low Show".intern()),
+                    None,
+                )],
+            })],
+        };
+        let high_priority = Epg {
+            logo_override: false,
+            priority: 0,
+            attributes: None,
+            children: vec![Arc::new(EpgChannel {
+                id: "demo.channel".intern(),
+                title: Some("High".intern()),
+                icon: Some("http://high/icon.png".intern()),
+                programmes: vec![EpgProgramme::new_all(
+                    30,
+                    40,
+                    "demo.channel".intern(),
+                    Some("High Show".intern()),
+                    None,
+                )],
+            })],
+        };
+
+        let epg = super::flatten_tvguide(vec![low_priority, high_priority]).expect("merged epg");
+        assert_eq!(epg.children.len(), 1);
+        assert_eq!(epg.children[0].title.as_deref(), Some("High"));
+        assert_eq!(epg.children[0].icon.as_deref(), Some("http://high/icon.png"));
+        assert_eq!(
+            epg.children[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
+            vec![(10, 20), (30, 40)],
+        );
+    }
+
+    #[test]
+    fn flatten_tvguide_uses_attributes_from_highest_priority_source() {
+        let low_priority = Epg {
+            logo_override: false,
+            priority: 10,
+            attributes: Some(HashMap::from([("generator-info-name".intern(), "low".intern())])),
+            children: vec![],
+        };
+        let high_priority = Epg {
+            logo_override: false,
+            priority: 0,
+            attributes: Some(HashMap::from([("generator-info-name".intern(), "high".intern())])),
+            children: vec![],
+        };
+
+        let epg = super::flatten_tvguide(vec![low_priority, high_priority]).expect("merged epg");
+
+        assert_eq!(
+            epg.attributes.as_ref().and_then(|attributes| attributes.get("generator-info-name")).map(AsRef::as_ref),
+            Some("high"),
+        );
+    }
+
+    #[test]
+    fn tvguide_merge_prefers_higher_priority_attributes_and_dedupes_channels() {
+        let low_priority = Epg {
+            logo_override: false,
+            priority: 10,
+            attributes: Some(HashMap::from([("generator-info-name".intern(), "low".intern())])),
+            children: vec![Arc::new(EpgChannel {
+                id: "demo.channel".intern(),
+                title: Some("Low".intern()),
+                icon: None,
+                programmes: vec![EpgProgramme::new_all(
+                    10,
+                    20,
+                    "demo.channel".intern(),
+                    Some("Low Show".intern()),
+                    None,
+                )],
+            })],
+        };
+        let high_priority = Epg {
+            logo_override: false,
+            priority: 0,
+            attributes: Some(HashMap::from([("generator-info-name".intern(), "high".intern())])),
+            children: vec![Arc::new(EpgChannel {
+                id: "demo.channel".intern(),
+                title: Some("High".intern()),
+                icon: Some("http://high/icon.png".intern()),
+                programmes: vec![EpgProgramme::new_all(
+                    30,
+                    40,
+                    "demo.channel".intern(),
+                    Some("High Show".intern()),
+                    None,
+                )],
+            })],
+        };
+
+        let epg = TVGuide::merge(vec![low_priority, high_priority]).expect("merged epg");
+
+        assert_eq!(
+            epg.attributes.as_ref().and_then(|attributes| attributes.get("generator-info-name")).map(AsRef::as_ref),
+            Some("high"),
+        );
+        assert_eq!(epg.children.len(), 1);
+        assert_eq!(epg.children[0].title.as_deref(), Some("High"));
+        assert_eq!(epg.children[0].icon.as_deref(), Some("http://high/icon.png"));
+        assert_eq!(
+            epg.children[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
+            vec![(10, 20), (30, 40)],
+        );
+    }
+
+    #[test]
+    fn flatten_tvguide_dedupes_duplicate_programmes_from_preferred_source() {
+        let high_priority = Epg {
+            logo_override: false,
+            priority: 0,
+            attributes: None,
+            children: vec![Arc::new(EpgChannel {
+                id: "demo.channel".intern(),
+                title: Some("High".intern()),
+                icon: None,
+                programmes: vec![
+                    EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("High Title".intern()), None),
+                    EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("Duplicate Title".intern()), None),
+                ],
+            })],
+        };
+        let low_priority = Epg {
+            logo_override: false,
+            priority: 10,
+            attributes: None,
+            children: vec![Arc::new(EpgChannel {
+                id: "demo.channel".intern(),
+                title: Some("Low".intern()),
+                icon: None,
+                programmes: vec![EpgProgramme::new_all(
+                    50,
+                    60,
+                    "demo.channel".intern(),
+                    Some("Low Title".intern()),
+                    None,
+                )],
+            })],
+        };
+
+        let epg = super::flatten_tvguide(vec![high_priority, low_priority]).expect("merged epg");
+
+        assert_eq!(epg.children.len(), 1);
+        assert_eq!(epg.children[0].programmes.len(), 2);
+        assert_eq!(
+            epg.children[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
+            vec![(30, 40), (50, 60)],
+        );
+        assert_eq!(epg.children[0].programmes[0].title.as_deref(), Some("High Title"));
+    }
+
+    #[test]
+    fn filter_keeps_same_channel_id_across_sources_for_flattening() {
+        let run_test = async move {
+            let dir = tempdir().unwrap();
+            let source_one = dir.path().join("one.xml");
+            let source_two = dir.path().join("two.xml");
+
+            fs::write(
+                &source_one,
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="demo.channel">
+    <display-name>Demo One</display-name>
+  </channel>
+  <programme start="20260425000000 +0000" stop="20260425010000 +0000" channel="demo.channel">
+    <title>Low Source</title>
+  </programme>
+</tv>
+"#,
+            )
+            .unwrap();
+            fs::write(
+                &source_two,
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="demo.channel">
+    <display-name>Demo Two</display-name>
+  </channel>
+  <programme start="20260425010000 +0000" stop="20260425020000 +0000" channel="demo.channel">
+    <title>High Source</title>
+  </programme>
+</tv>
+"#,
+            )
+            .unwrap();
+
+            let tv_guide = TVGuide::new(vec![
+                PersistedEpgSource { file_path: source_one.clone(), priority: 10, logo_override: false },
+                PersistedEpgSource { file_path: source_two.clone(), priority: 0, logo_override: false },
+            ]);
+
+            let mut id_cache = EpgIdCache::new(None);
+            id_cache.channel_epg_id.insert("demo.channel".intern());
+
+            let epgs = tv_guide.filter(&mut id_cache).await.expect("filtered epgs");
+            assert_eq!(epgs.len(), 2);
+
+            let flattened = super::flatten_tvguide(epgs).expect("flattened epg");
+
+            assert_eq!(flattened.children.len(), 1);
+            assert_eq!(flattened.children[0].programmes.len(), 2);
+            let titles: Vec<_> =
+                flattened.children[0].programmes.iter().filter_map(|programme| programme.title.as_deref()).collect();
+            assert_eq!(titles, vec!["Low Source", "High Source"]);
+        };
+
+        tokio::runtime::Runtime::new().unwrap().block_on(run_test);
+    }
+
+    #[test]
+    fn filter_accumulates_processed_ids_across_sources() {
+        let run_test = async move {
+            let dir = tempdir().unwrap();
+            let source_one = dir.path().join("one.xml");
+            let source_two = dir.path().join("two.xml");
+
+            fs::write(
+                &source_one,
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="demo.one">
+    <display-name>Demo One</display-name>
+  </channel>
+  <programme start="20260425000000 +0000" stop="20260425010000 +0000" channel="demo.one">
+    <title>First Source</title>
+  </programme>
+</tv>
+"#,
+            )
+            .unwrap();
+            fs::write(
+                &source_two,
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="demo.two">
+    <display-name>Demo Two</display-name>
+  </channel>
+  <programme start="20260425010000 +0000" stop="20260425020000 +0000" channel="demo.two">
+    <title>Second Source</title>
+  </programme>
+</tv>
+"#,
+            )
+            .unwrap();
+
+            let tv_guide = TVGuide::new(vec![
+                PersistedEpgSource { file_path: source_one.clone(), priority: 10, logo_override: false },
+                PersistedEpgSource { file_path: source_two.clone(), priority: 0, logo_override: false },
+            ]);
+
+            let mut id_cache = EpgIdCache::new(None);
+            id_cache.channel_epg_id.insert("demo.one".intern());
+            id_cache.channel_epg_id.insert("demo.two".intern());
+
+            let epgs = tv_guide.filter(&mut id_cache).await.expect("filtered epgs");
+
+            assert_eq!(epgs.len(), 2);
+            assert!(id_cache.processed.contains("demo.one"));
+            assert!(id_cache.processed.contains("demo.two"));
+        };
+
+        tokio::runtime::Runtime::new().unwrap().block_on(run_test);
+    }
+
+    #[test]
+    fn filter_backfills_metadata_from_duplicate_channel_tags_in_same_source() {
+        let run_test = async move {
+            let dir = tempdir().unwrap();
+            let source = dir.path().join("duplicate-channel.xml");
+
+            fs::write(
+                &source,
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<tv>
+  <channel id="demo.channel">
+    <display-name>Recovered Title</display-name>
+  </channel>
+  <channel id="demo.channel">
+    <icon src="http://example/icon.png"/>
+  </channel>
+  <programme start="20260425000000 +0000" stop="20260425010000 +0000" channel="demo.channel">
+    <title>Show</title>
+  </programme>
+</tv>
+"#,
+            )
+            .unwrap();
+
+            let tv_guide =
+                TVGuide::new(vec![PersistedEpgSource { file_path: source, priority: 0, logo_override: false }]);
+
+            let mut id_cache = EpgIdCache::new(None);
+            id_cache.channel_epg_id.insert("demo.channel".intern());
+
+            let epgs = tv_guide.filter(&mut id_cache).await.expect("filtered epg");
+
+            assert_eq!(epgs.len(), 1);
+            assert_eq!(epgs[0].children.len(), 1);
+            assert_eq!(epgs[0].children[0].title.as_deref(), Some("Recovered Title"));
+            assert_eq!(epgs[0].children[0].icon.as_deref(), Some("http://example/icon.png"));
+        };
+
+        tokio::runtime::Runtime::new().unwrap().block_on(run_test);
+    }
 
     #[ignore = "requires a local XMLTV fixture under /tmp"]
     #[test]
@@ -658,9 +990,7 @@ mod tests {
                 }
             }
         };
-        tokio::runtime::Runtime::new()
-            .unwrap()
-            .block_on(run_test());
+        tokio::runtime::Runtime::new().unwrap().block_on(run_test());
     }
 
     #[test]
@@ -673,7 +1003,11 @@ mod tests {
     /// // This will assert that various channel names are normalized as expected.
     /// ```
     fn normalize() {
-        let mut epg_smart_cfg_dto = EpgSmartMatchConfigDto { enabled: true, name_prefix: EpgNamePrefix::Suffix(".".to_string()), ..Default::default() };
+        let mut epg_smart_cfg_dto = EpgSmartMatchConfigDto {
+            enabled: true,
+            name_prefix: EpgNamePrefix::Suffix(".".to_string()),
+            ..Default::default()
+        };
         let _ = epg_smart_cfg_dto.prepare();
         let epg_smart_cfg = EpgSmartMatchConfig::from(epg_smart_cfg_dto);
         println!("{epg_smart_cfg:?}");
@@ -703,7 +1037,11 @@ mod tests {
     /// ```
     fn test_metaphone() {
         let metaphone = Metaphone::default();
-        let mut epg_smart_cfg_dto = EpgSmartMatchConfigDto { enabled: true, name_prefix: EpgNamePrefix::Suffix(".".to_string()), ..Default::default() };
+        let mut epg_smart_cfg_dto = EpgSmartMatchConfigDto {
+            enabled: true,
+            name_prefix: EpgNamePrefix::Suffix(".".to_string()),
+            ..Default::default()
+        };
         let _ = epg_smart_cfg_dto.prepare();
         let epg_smart_cfg = EpgSmartMatchConfig::from(epg_smart_cfg_dto);
         println!("{epg_smart_cfg:?}");

--- a/backend/src/processing/parser/xmltv.rs
+++ b/backend/src/processing/parser/xmltv.rs
@@ -98,14 +98,7 @@ impl TVGuide {
 
         let mut channels_by_source = Vec::with_capacity(epgs.len());
         for epg in epgs {
-            let mut source_channels = Vec::with_capacity(epg.children.len());
-            for channel_arc in epg.children {
-                let Ok(channel) = Arc::try_unwrap(channel_arc) else {
-                    error!("Failed to unwrap epg channel");
-                    continue;
-                };
-                source_channels.push(channel);
-            }
+            let source_channels = epg.children.into_iter().map(Arc::unwrap_or_clone).collect();
             channels_by_source.push((epg.priority, source_channels));
         }
 
@@ -601,14 +594,7 @@ pub fn flatten_tvguide(mut tv_guides: Vec<Epg>) -> Option<Epg> {
     let mut channels_by_source = Vec::with_capacity(tv_guides.len());
 
     for guide in tv_guides.drain(..) {
-        let mut source_channels = Vec::with_capacity(guide.children.len());
-        for channel_arc in guide.children {
-            let Ok(channel) = Arc::try_unwrap(channel_arc) else {
-                error!("Failed to unwrap epg channel");
-                continue;
-            };
-            source_channels.push(channel);
-        }
+        let source_channels = guide.children.into_iter().map(Arc::unwrap_or_clone).collect();
         channels_by_source.push((guide.priority, source_channels));
     }
 
@@ -763,6 +749,64 @@ mod tests {
             epg.children[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
             vec![(10, 20), (30, 40)],
         );
+    }
+
+    #[test]
+    fn tvguide_merge_keeps_shared_arc_channels() {
+        let shared_channel = Arc::new(EpgChannel {
+            id: "demo.channel".intern(),
+            title: Some("Shared".intern()),
+            icon: Some("http://shared/icon.png".intern()),
+            programmes: vec![EpgProgramme::new_all(
+                10,
+                20,
+                "demo.channel".intern(),
+                Some("Shared Show".intern()),
+                None,
+            )],
+        });
+
+        let epg = TVGuide::merge(vec![Epg {
+            logo_override: false,
+            priority: 0,
+            attributes: None,
+            children: vec![Arc::clone(&shared_channel)],
+        }])
+        .expect("merged epg");
+
+        assert_eq!(Arc::strong_count(&shared_channel), 1);
+        assert_eq!(epg.children.len(), 1);
+        assert_eq!(epg.children[0].title.as_deref(), Some("Shared"));
+        assert_eq!(epg.children[0].icon.as_deref(), Some("http://shared/icon.png"));
+    }
+
+    #[test]
+    fn flatten_tvguide_keeps_shared_arc_channels() {
+        let shared_channel = Arc::new(EpgChannel {
+            id: "demo.channel".intern(),
+            title: Some("Shared".intern()),
+            icon: Some("http://shared/icon.png".intern()),
+            programmes: vec![EpgProgramme::new_all(
+                10,
+                20,
+                "demo.channel".intern(),
+                Some("Shared Show".intern()),
+                None,
+            )],
+        });
+
+        let epg = super::flatten_tvguide(vec![Epg {
+            logo_override: false,
+            priority: 0,
+            attributes: None,
+            children: vec![Arc::clone(&shared_channel)],
+        }])
+        .expect("merged epg");
+
+        assert_eq!(Arc::strong_count(&shared_channel), 1);
+        assert_eq!(epg.children.len(), 1);
+        assert_eq!(epg.children[0].title.as_deref(), Some("Shared"));
+        assert_eq!(epg.children[0].icon.as_deref(), Some("http://shared/icon.png"));
     }
 
     #[test]

--- a/backend/src/utils/epg_merge.rs
+++ b/backend/src/utils/epg_merge.rs
@@ -1,0 +1,243 @@
+use shared::model::{EpgChannel, EpgProgramme};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+#[derive(Clone, Hash, Eq, PartialEq)]
+pub(crate) struct ProgrammeMergeKey {
+    start: i64,
+    stop: i64,
+}
+
+impl From<&EpgProgramme> for ProgrammeMergeKey {
+    fn from(programme: &EpgProgramme) -> Self {
+        Self { start: programme.start, stop: programme.stop }
+    }
+}
+
+pub(crate) fn dedupe_channel_programmes(channel: &mut EpgChannel) -> HashSet<ProgrammeMergeKey> {
+    let mut seen = HashMap::new();
+    let mut deduped = Vec::with_capacity(channel.programmes.len());
+
+    for mut programme in std::mem::take(&mut channel.programmes) {
+        let key = ProgrammeMergeKey::from(&programme);
+        if let Some(existing_idx) = seen.get(&key) {
+            backfill_programme_metadata(&mut deduped[*existing_idx], &mut programme);
+        } else {
+            seen.insert(key.clone(), deduped.len());
+            deduped.push(programme);
+        }
+    }
+
+    channel.programmes = deduped;
+    seen.into_keys().collect()
+}
+
+pub(crate) fn merge_missing_channel_programmes<I>(
+    channel: &mut EpgChannel,
+    programmes: &mut HashSet<ProgrammeMergeKey>,
+    incoming: I,
+) where
+    I: IntoIterator<Item = EpgProgramme>,
+{
+    let mut programme_index = channel
+        .programmes
+        .iter()
+        .enumerate()
+        .map(|(idx, programme)| (ProgrammeMergeKey::from(programme), idx))
+        .collect::<HashMap<_, _>>();
+
+    for mut programme in incoming {
+        let key = ProgrammeMergeKey::from(&programme);
+        if programmes.insert(key.clone()) {
+            programme_index.insert(key, channel.programmes.len());
+            channel.programmes.push(programme);
+        } else if let Some(existing_idx) = programme_index.get(&key) {
+            backfill_programme_metadata(&mut channel.programmes[*existing_idx], &mut programme);
+        }
+    }
+}
+
+pub(crate) fn merge_prioritized_channels(mut channels_by_source: Vec<(i16, Vec<EpgChannel>)>) -> Vec<EpgChannel> {
+    struct ChannelMergeAcc {
+        priority: i16,
+        channel: EpgChannel,
+        programmes: HashSet<ProgrammeMergeKey>,
+    }
+
+    let mut merged: HashMap<Arc<str>, ChannelMergeAcc> = HashMap::new();
+    channels_by_source.sort_by_key(|(priority, _)| *priority);
+
+    for (priority, channels) in channels_by_source.drain(..) {
+        for mut channel in channels {
+            match merged.entry(channel.id.clone()) {
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    let acc = entry.get_mut();
+                    debug_assert!(priority >= acc.priority);
+                    backfill_channel_metadata(&mut acc.channel, &mut channel);
+                    merge_missing_channel_programmes(&mut acc.channel, &mut acc.programmes, channel.programmes);
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    let programmes = dedupe_channel_programmes(&mut channel);
+                    entry.insert(ChannelMergeAcc { priority, channel, programmes });
+                }
+            }
+        }
+    }
+
+    for entry in merged.values_mut() {
+        entry.channel.programmes.sort_by_key(|programme| programme.start);
+    }
+
+    let mut channels = merged.into_values().map(|entry| entry.channel).collect::<Vec<_>>();
+    channels.sort_by(|left, right| left.id.cmp(&right.id));
+    channels
+}
+
+fn backfill_programme_metadata(existing: &mut EpgProgramme, incoming: &mut EpgProgramme) {
+    if existing.title.is_none() {
+        existing.title = incoming.title.take();
+    }
+    if existing.desc.is_none() {
+        existing.desc = incoming.desc.take();
+    }
+}
+
+fn backfill_channel_metadata(existing: &mut EpgChannel, incoming: &mut EpgChannel) {
+    if existing.title.is_none() {
+        existing.title = incoming.title.take();
+    }
+    if existing.icon.is_none() {
+        existing.icon = incoming.icon.take();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        dedupe_channel_programmes, merge_missing_channel_programmes, merge_prioritized_channels, ProgrammeMergeKey,
+    };
+    use shared::model::{EpgChannel, EpgProgramme};
+    use shared::utils::Internable;
+    use std::collections::HashSet;
+
+    #[test]
+    fn dedupe_channel_programmes_backfills_missing_metadata_from_duplicates() {
+        let mut channel = EpgChannel {
+            id: "demo.channel".intern(),
+            title: None,
+            icon: None,
+            programmes: vec![
+                EpgProgramme::new_all(10, 20, "demo.channel".intern(), None, None),
+                EpgProgramme::new_all(
+                    10,
+                    20,
+                    "demo.channel".intern(),
+                    Some("Recovered title".intern()),
+                    Some("Recovered desc".intern()),
+                ),
+            ],
+        };
+
+        let keys = dedupe_channel_programmes(&mut channel);
+
+        assert_eq!(keys.len(), 1);
+        assert_eq!(channel.programmes.len(), 1);
+        assert_eq!(channel.programmes[0].title.as_deref(), Some("Recovered title"));
+        assert_eq!(channel.programmes[0].desc.as_deref(), Some("Recovered desc"));
+    }
+
+    #[test]
+    fn merge_missing_channel_programmes_backfills_missing_metadata_from_duplicates() {
+        let mut channel = EpgChannel {
+            id: "demo.channel".intern(),
+            title: None,
+            icon: None,
+            programmes: vec![EpgProgramme::new_all(10, 20, "demo.channel".intern(), None, None)],
+        };
+        let mut programmes = HashSet::from([ProgrammeMergeKey::from(&channel.programmes[0])]);
+
+        merge_missing_channel_programmes(
+            &mut channel,
+            &mut programmes,
+            vec![EpgProgramme::new_all(
+                10,
+                20,
+                "demo.channel".intern(),
+                Some("Recovered title".intern()),
+                Some("Recovered desc".intern()),
+            )],
+        );
+
+        assert_eq!(channel.programmes.len(), 1);
+        assert_eq!(channel.programmes[0].title.as_deref(), Some("Recovered title"));
+        assert_eq!(channel.programmes[0].desc.as_deref(), Some("Recovered desc"));
+    }
+
+    #[test]
+    fn merge_prioritized_channels_prefers_higher_priority_metadata_and_merges_all_programmes() {
+        let low_priority = EpgChannel {
+            id: "demo.channel".intern(),
+            title: Some("Low".intern()),
+            icon: Some("http://low/icon.png".intern()),
+            programmes: vec![EpgProgramme::new_all(10, 20, "demo.channel".intern(), Some("Low Show".intern()), None)],
+        };
+        let high_priority = EpgChannel {
+            id: "demo.channel".intern(),
+            title: Some("High".intern()),
+            icon: Some("http://high/icon.png".intern()),
+            programmes: vec![EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("High Show".intern()), None)],
+        };
+        let same_priority = EpgChannel {
+            id: "demo.channel".intern(),
+            title: Some("Same".intern()),
+            icon: Some("http://same/icon.png".intern()),
+            programmes: vec![
+                EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("Duplicate".intern()), None),
+                EpgProgramme::new_all(50, 60, "demo.channel".intern(), Some("Second Show".intern()), None),
+            ],
+        };
+
+        let channels = merge_prioritized_channels(vec![
+            (10, vec![low_priority]),
+            (0, vec![high_priority]),
+            (0, vec![same_priority]),
+        ]);
+
+        assert_eq!(channels.len(), 1);
+        assert_eq!(channels[0].title.as_deref(), Some("High"));
+        assert_eq!(channels[0].icon.as_deref(), Some("http://high/icon.png"));
+        assert_eq!(channels[0].programmes.len(), 3);
+        assert_eq!(
+            channels[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
+            vec![(10, 20), (30, 40), (50, 60)],
+        );
+    }
+
+    #[test]
+    fn merge_prioritized_channels_backfills_missing_channel_metadata() {
+        let high_priority = EpgChannel {
+            id: "demo.channel".intern(),
+            title: None,
+            icon: None,
+            programmes: vec![EpgProgramme::new_all(30, 40, "demo.channel".intern(), Some("High Show".intern()), None)],
+        };
+        let low_priority = EpgChannel {
+            id: "demo.channel".intern(),
+            title: Some("Recovered Title".intern()),
+            icon: Some("http://recovered/icon.png".intern()),
+            programmes: vec![EpgProgramme::new_all(50, 60, "demo.channel".intern(), Some("Low Show".intern()), None)],
+        };
+
+        let channels = merge_prioritized_channels(vec![(0, vec![high_priority]), (10, vec![low_priority])]);
+
+        assert_eq!(channels.len(), 1);
+        assert_eq!(channels[0].title.as_deref(), Some("Recovered Title"));
+        assert_eq!(channels[0].icon.as_deref(), Some("http://recovered/icon.png"));
+        assert_eq!(
+            channels[0].programmes.iter().map(|programme| (programme.start, programme.stop)).collect::<Vec<_>>(),
+            vec![(30, 40), (50, 60)],
+        );
+    }
+}

--- a/backend/src/utils/mod.rs
+++ b/backend/src/utils/mod.rs
@@ -2,6 +2,7 @@ mod sys_utils;
 mod compression;
 mod file;
 mod network;
+mod epg_merge;
 mod crypto_utils;
 mod step_measure;
 mod logging;
@@ -67,6 +68,7 @@ pub use with;
 
 pub use self::binary_utils::*;
 pub use self::db_viewer::*;
+pub(crate) use self::epg_merge::*;
 pub use self::epg_parser::*;
 pub use self::geoip::*;
 pub use self::logging::*;


### PR DESCRIPTION
## Summary
- centralize EPG channel/programme merge behavior in shared helpers
- preserve higher-priority XMLTV metadata while filling programme gaps from lower-priority sources
- validate custom EPG URLs and backfill missing metadata from duplicate channels and programmes

## Testing
- cargo test -p tuliprox utils::epg_merge::tests::
- cargo test -p tuliprox processing::parser::xmltv::tests::
- cargo test -p tuliprox api::endpoints::v1_api_playlist::tests::

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Electronic Program Guide (EPG) program deduplication when programs appear in multiple sources.
  * Enhanced channel merging to intelligently combine duplicate channels across sources.
  * Improved metadata selection using priority-based logic.
  * Added validation requiring HTTP/HTTPS schemes for custom playlist URLs.

* **Refactor**
  * Streamlined EPG processing pipeline for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->